### PR TITLE
feat: settings page, camera auto-disconnect, and layout fixes

### DIFF
--- a/app/components/CameraImage.client.vue
+++ b/app/components/CameraImage.client.vue
@@ -84,7 +84,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="el" class="relative size-full">
+  <!-- Centered so a photo whose aspect ratio differs from the container sits in
+       the middle instead of hugging the left edge. -->
+  <div ref="el" class="relative flex size-full items-center justify-center">
     <img
       v-if="state === 'loaded' && objectUrl"
       :src="objectUrl"

--- a/app/components/CameraStatusChip.vue
+++ b/app/components/CameraStatusChip.vue
@@ -23,7 +23,7 @@ const tooltip = computed(() => (info.value ? (info.value.ssid ?? info.value.host
       to="/settings"
       class="block rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
       :class="collapsed ? '' : 'w-full'"
-      aria-label="Camera settings"
+      :aria-label="`Camera ${meta.label.toLowerCase()}. Open settings`"
     >
       <UBadge :color="meta.color" variant="subtle" size="md" :class="collapsed ? 'px-1.5' : 'w-full justify-start'">
         <UIcon :name="meta.icon" class="size-3.5 shrink-0" :class="meta.spin ? 'animate-spin' : ''" />

--- a/app/components/CameraStatusChip.vue
+++ b/app/components/CameraStatusChip.vue
@@ -19,9 +19,16 @@ const tooltip = computed(() => (info.value ? (info.value.ssid ?? info.value.host
 
 <template>
   <UTooltip :text="tooltip">
-    <UBadge :color="meta.color" variant="subtle" size="md" :class="collapsed ? 'px-1.5' : 'w-full justify-start'">
-      <UIcon :name="meta.icon" class="size-3.5 shrink-0" :class="meta.spin ? 'animate-spin' : ''" />
-      <span v-if="!collapsed">{{ meta.label }}</span>
-    </UBadge>
+    <NuxtLink
+      to="/settings"
+      class="block rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      :class="collapsed ? '' : 'w-full'"
+      aria-label="Camera settings"
+    >
+      <UBadge :color="meta.color" variant="subtle" size="md" :class="collapsed ? 'px-1.5' : 'w-full justify-start'">
+        <UIcon :name="meta.icon" class="size-3.5 shrink-0" :class="meta.spin ? 'animate-spin' : ''" />
+        <span v-if="!collapsed">{{ meta.label }}</span>
+      </UBadge>
+    </NuxtLink>
   </UTooltip>
 </template>

--- a/app/components/DownloadOptionsModal.vue
+++ b/app/components/DownloadOptionsModal.vue
@@ -1,32 +1,13 @@
 <script setup lang="ts">
 import type { MediaItem } from "~/types/media";
-import { WATERMARK_POSITIONS, type WatermarkPosition } from "~/utils/watermark";
 
 const props = defineProps<{ items: MediaItem[] }>();
 
 const emit = defineEmits<{ close: [confirmed: boolean] }>();
 
-const { settings } = useWatermarkSettings();
-
 const photos = computed(() => props.items.filter((item) => item.type === "photo"));
 const videos = computed(() => props.items.filter((item) => item.type === "video"));
 const previewSrc = computed(() => photos.value[0]?.srcUrl);
-
-const positionLabels: Record<WatermarkPosition, string> = {
-  "top-left": "Top left",
-  "top-right": "Top right",
-  "bottom-left": "Bottom left",
-  "bottom-center": "Bottom center",
-  "bottom-right": "Bottom right",
-};
-
-const anchorClasses: Record<WatermarkPosition, string> = {
-  "top-left": "left-2 top-2",
-  "top-right": "right-2 top-2",
-  "bottom-left": "bottom-2 left-2",
-  "bottom-center": "bottom-2 left-1/2 -translate-x-1/2",
-  "bottom-right": "bottom-2 right-2",
-};
 
 const summary = computed(() => {
   const parts: string[] = [];
@@ -44,44 +25,10 @@ const summary = computed(() => {
     :ui="{ footer: 'justify-end' }"
   >
     <template #body>
-      <div class="space-y-5">
-        <template v-if="photos.length > 0">
-          <USwitch
-            v-model="settings.enabled"
-            label="Apply Luna Ultra watermark"
-            description="The official watermark is rendered into photos. Videos transfer untouched."
-          />
-
-          <div v-if="settings.enabled" class="grid grid-cols-[1fr_auto] items-start gap-4">
-            <WatermarkCanvas :src="previewSrc" />
-            <UFormField label="Position" :help="positionLabels[settings.position]">
-              <div class="relative h-20 w-32 rounded-lg border border-default bg-muted">
-                <button
-                  v-for="position in WATERMARK_POSITIONS"
-                  :key="position"
-                  type="button"
-                  class="absolute flex size-6 cursor-pointer items-center justify-center rounded-md border transition"
-                  :class="[
-                    anchorClasses[position],
-                    settings.position === position
-                      ? 'border-transparent bg-primary text-inverted'
-                      : 'border-default bg-elevated text-muted hover:border-accented hover:text-default',
-                  ]"
-                  :aria-label="positionLabels[position]"
-                  :aria-pressed="settings.position === position"
-                  @click="settings.position = position"
-                >
-                  <span class="block size-1.5 rounded-[2px] bg-current" />
-                </button>
-              </div>
-            </UFormField>
-          </div>
-        </template>
-
-        <p v-else class="text-sm text-muted">
-          Videos transfer untouched. Watermarking currently applies to photos only.
-        </p>
-      </div>
+      <WatermarkSettingsForm v-if="photos.length > 0" :preview-src="previewSrc" />
+      <p v-else class="text-sm text-muted">
+        Videos transfer untouched. Watermarking currently applies to photos only.
+      </p>
     </template>
 
     <template #footer>

--- a/app/components/MediaPreview.vue
+++ b/app/components/MediaPreview.vue
@@ -59,6 +59,17 @@ const takenLabel = computed(() => {
   });
 });
 
+const moreItems = computed(() => [
+  [
+    {
+      label: "Delete from camera",
+      icon: "i-lucide-trash-2",
+      color: "error" as const,
+      onSelect: () => emit("delete"),
+    },
+  ],
+]);
+
 defineShortcuts({
   arrowleft: () => {
     if (open.value) emit("prev");
@@ -83,12 +94,15 @@ defineShortcuts({
           </div>
           <div class="flex items-center gap-1.5">
             <UButton icon="i-lucide-arrow-down-to-line" label="Download" size="sm" color="neutral" variant="outline" @click="emit('download')" />
-            <UButton icon="i-lucide-trash-2" size="sm" color="error" variant="ghost" aria-label="Delete file" @click="emit('delete')" />
+            <UDropdownMenu :items="moreItems">
+              <UButton icon="i-lucide-ellipsis" size="sm" color="neutral" variant="ghost" aria-label="More actions" />
+            </UDropdownMenu>
+            <span class="mx-1 h-5 w-px bg-default" aria-hidden="true" />
             <UButton icon="i-lucide-x" size="sm" color="neutral" variant="ghost" aria-label="Close preview" @click="open = false" />
           </div>
         </div>
 
-        <div class="relative flex min-h-0 flex-1 items-center justify-center bg-black/95 dark:bg-black">
+        <div class="relative flex min-h-0 flex-1 items-center justify-center bg-black/95 px-16 dark:bg-black">
           <!-- Play the low-res LRV proxy when available; the full-res file can
                be hundreds of MB and is meant for download, not preview. -->
           <video
@@ -146,7 +160,7 @@ defineShortcuts({
             size="lg"
             color="neutral"
             variant="solid"
-            class="absolute left-4 top-1/2 -translate-y-1/2"
+            class="absolute left-3 top-1/2 -translate-y-1/2"
             aria-label="Previous file"
             @click="emit('prev')"
           />
@@ -156,7 +170,7 @@ defineShortcuts({
             size="lg"
             color="neutral"
             variant="solid"
-            class="absolute right-4 top-1/2 -translate-y-1/2"
+            class="absolute right-3 top-1/2 -translate-y-1/2"
             aria-label="Next file"
             @click="emit('next')"
           />

--- a/app/components/MediaPreview.vue
+++ b/app/components/MediaPreview.vue
@@ -70,15 +70,20 @@ const moreItems = computed(() => [
   ],
 ]);
 
+// While the overflow menu is open it owns the keyboard: Escape should close
+// the menu, not the whole preview, and the arrows should not navigate files
+// underneath it.
+const moreOpen = ref(false);
+
 defineShortcuts({
   arrowleft: () => {
-    if (open.value) emit("prev");
+    if (open.value && !moreOpen.value) emit("prev");
   },
   arrowright: () => {
-    if (open.value) emit("next");
+    if (open.value && !moreOpen.value) emit("next");
   },
   escape: () => {
-    if (open.value) open.value = false;
+    if (open.value && !moreOpen.value) open.value = false;
   },
 });
 </script>
@@ -94,7 +99,7 @@ defineShortcuts({
           </div>
           <div class="flex items-center gap-1.5">
             <UButton icon="i-lucide-arrow-down-to-line" label="Download" size="sm" color="neutral" variant="outline" @click="emit('download')" />
-            <UDropdownMenu :items="moreItems">
+            <UDropdownMenu v-model:open="moreOpen" :items="moreItems">
               <UButton icon="i-lucide-ellipsis" size="sm" color="neutral" variant="ghost" aria-label="More actions" />
             </UDropdownMenu>
             <span class="mx-1 h-5 w-px bg-default" aria-hidden="true" />

--- a/app/components/RawImage.client.vue
+++ b/app/components/RawImage.client.vue
@@ -200,7 +200,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="el" class="relative size-full">
+  <!-- Centered so a photo whose aspect ratio differs from the container sits in
+       the middle instead of hugging the left edge. -->
+  <div ref="el" class="relative flex size-full items-center justify-center">
     <img v-if="state === 'loaded' && imgSrc" :src="imgSrc" alt="" draggable="false" :class="imgClass" />
 
     <slot v-else-if="state === 'nopreview' || state === 'error'" name="fallback" :ext="ext" :reason="reason">

--- a/app/components/WatermarkSettingsForm.vue
+++ b/app/components/WatermarkSettingsForm.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { WATERMARK_POSITIONS, type WatermarkPosition } from "~/utils/watermark";
+
+defineProps<{ previewSrc?: string }>();
+
+const { settings } = useWatermarkSettings();
+
+const positionLabels: Record<WatermarkPosition, string> = {
+  "top-left": "Top left",
+  "top-right": "Top right",
+  "bottom-left": "Bottom left",
+  "bottom-center": "Bottom center",
+  "bottom-right": "Bottom right",
+};
+
+const anchorClasses: Record<WatermarkPosition, string> = {
+  "top-left": "left-2 top-2",
+  "top-right": "right-2 top-2",
+  "bottom-left": "bottom-2 left-2",
+  "bottom-center": "bottom-2 left-1/2 -translate-x-1/2",
+  "bottom-right": "bottom-2 right-2",
+};
+</script>
+
+<template>
+  <div class="space-y-5">
+    <USwitch
+      v-model="settings.enabled"
+      label="Apply Luna Ultra watermark"
+      description="The official watermark is rendered into photos. Videos transfer untouched."
+    />
+
+    <div v-if="settings.enabled" class="grid grid-cols-[1fr_auto] items-start gap-4">
+      <WatermarkCanvas :src="previewSrc" />
+      <UFormField label="Position" :help="positionLabels[settings.position]">
+        <div class="relative h-20 w-32 rounded-lg border border-default bg-muted">
+          <button
+            v-for="position in WATERMARK_POSITIONS"
+            :key="position"
+            type="button"
+            class="absolute flex size-6 cursor-pointer items-center justify-center rounded-md border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :class="[
+              anchorClasses[position],
+              settings.position === position
+                ? 'border-transparent bg-primary text-inverted'
+                : 'border-default bg-elevated text-muted hover:border-accented hover:text-default',
+            ]"
+            :aria-label="positionLabels[position]"
+            :aria-pressed="settings.position === position"
+            @click="settings.position = position"
+          >
+            <span class="block size-1.5 rounded-[2px] bg-current" />
+          </button>
+        </div>
+      </UFormField>
+    </div>
+  </div>
+</template>

--- a/app/composables/useCamera.ts
+++ b/app/composables/useCamera.ts
@@ -1,5 +1,6 @@
 import type { CameraInfo, CameraStatus, MediaItem } from "~/types/media";
 import { lunaClient } from "~/utils/lunaClient";
+import { armCameraHealth, disarmCameraHealth, FAILURE_THRESHOLD } from "~/utils/cameraHealth";
 
 const DEFAULT_HOST = "192.168.42.1";
 
@@ -41,6 +42,9 @@ export function useCamera() {
       status.value = "connected";
       error.value = null;
       retryAttempt.value = 0;
+      armCameraHealth(() => {
+        void forceDisconnect();
+      });
       await refreshLibrary();
     } catch {
       status.value = "disconnected";
@@ -111,6 +115,9 @@ export function useCamera() {
       status.value = "connected";
       // Auto-reconnect only after a session the user established succeeds
       wantConnection.value = true;
+      armCameraHealth(() => {
+        void forceDisconnect();
+      });
       retryAttempt.value = 0;
       await refreshLibrary();
     } catch (e) {
@@ -120,14 +127,34 @@ export function useCamera() {
     }
   }
 
-  async function disconnect() {
-    wantConnection.value = false;
+  /**
+   * Tear down the session without touching `wantConnection`. Shared by the
+   * user-initiated disconnect and the health-detector disconnect.
+   */
+  async function teardown() {
     clearRetryTimer();
+    disarmCameraHealth();
     await lunaClient.disconnect();
     status.value = "disconnected";
     info.value = null;
     library.value = [];
+  }
+
+  async function disconnect() {
+    wantConnection.value = false;
+    await teardown();
     error.value = null;
+  }
+
+  /**
+   * The camera stopped answering. Drop the session and leave it dropped:
+   * clearing `wantConnection` keeps the backoff reconnect loop dormant so it
+   * cannot immediately undo this. The user reconnects deliberately.
+   */
+  async function forceDisconnect() {
+    wantConnection.value = false;
+    await teardown();
+    error.value = `Lost contact with the camera. Disconnected after ${FAILURE_THRESHOLD} failed requests.`;
   }
 
   /** Remove items locally after the camera confirms deletion. */

--- a/app/composables/useCamera.ts
+++ b/app/composables/useCamera.ts
@@ -83,6 +83,11 @@ export function useCamera() {
       library.value = [];
       error.value = "Lost connection to the camera. Reconnecting…";
       retryAttempt.value = 0;
+      // This is a known socket close, not a silently-unresponsive camera: disarm the
+      // health detector so its failure count can't race scheduleReconnect() below and
+      // trigger forceDisconnect(), which would cancel this reconnect. It re-arms itself
+      // once tryReconnect() succeeds again.
+      disarmCameraHealth();
       scheduleReconnect();
     });
   }

--- a/app/composables/useCamera.ts
+++ b/app/composables/useCamera.ts
@@ -1,5 +1,5 @@
 import type { CameraInfo, CameraStatus, MediaItem } from "~/types/media";
-import { lunaClient } from "~/utils/lunaClient";
+import { lunaClient, probeCamera } from "~/utils/lunaClient";
 import { armCameraHealth, disarmCameraHealth, FAILURE_THRESHOLD } from "~/utils/cameraHealth";
 
 const DEFAULT_HOST = "192.168.42.1";
@@ -17,7 +17,9 @@ export function useCamera() {
   const library = useState<MediaItem[]>("camera-library", () => []);
   const host = useState<string>("camera-host", () => {
     if (import.meta.client) {
-      const stored = localStorage.getItem(HOST_STORAGE_KEY);
+      // Trim on read as well as on write: a blank stored value is treated as
+      // absent so it falls back to the default instead of an empty address.
+      const stored = localStorage.getItem(HOST_STORAGE_KEY)?.trim();
       if (stored) return stored;
     }
     return DEFAULT_HOST;
@@ -57,9 +59,12 @@ export function useCamera() {
       status.value = "connected";
       error.value = null;
       retryAttempt.value = 0;
-      armCameraHealth(() => {
-        void forceDisconnect();
-      });
+      armCameraHealth(
+        () => {
+          void forceDisconnect();
+        },
+        () => probeCamera(host.value),
+      );
       await refreshLibrary();
     } catch {
       status.value = "disconnected";
@@ -135,9 +140,12 @@ export function useCamera() {
       status.value = "connected";
       // Auto-reconnect only after a session the user established succeeds
       wantConnection.value = true;
-      armCameraHealth(() => {
-        void forceDisconnect();
-      });
+      armCameraHealth(
+        () => {
+          void forceDisconnect();
+        },
+        () => probeCamera(host.value),
+      );
       retryAttempt.value = 0;
       await refreshLibrary();
     } catch (e) {
@@ -174,7 +182,7 @@ export function useCamera() {
   async function forceDisconnect() {
     wantConnection.value = false;
     await teardown();
-    error.value = `Lost contact with the camera. Disconnected after ${FAILURE_THRESHOLD} failed requests.`;
+    error.value = `Lost contact with the camera. Disconnected after ${FAILURE_THRESHOLD} failed requests and a failed health check.`;
   }
 
   /** Remove items locally after the camera confirms deletion. */

--- a/app/composables/useCamera.ts
+++ b/app/composables/useCamera.ts
@@ -3,6 +3,7 @@ import { lunaClient } from "~/utils/lunaClient";
 import { armCameraHealth, disarmCameraHealth, FAILURE_THRESHOLD } from "~/utils/cameraHealth";
 
 const DEFAULT_HOST = "192.168.42.1";
+const HOST_STORAGE_KEY = "luna-camera-host";
 
 /** Reconnect backoff schedule; the last delay repeats until reconnected. */
 const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000, 15000];
@@ -14,12 +15,26 @@ export function useCamera() {
   const status = useState<CameraStatus>("camera-status", () => "disconnected");
   const info = useState<CameraInfo | null>("camera-info", () => null);
   const library = useState<MediaItem[]>("camera-library", () => []);
-  const host = useState<string>("camera-host", () => DEFAULT_HOST);
+  const host = useState<string>("camera-host", () => {
+    if (import.meta.client) {
+      const stored = localStorage.getItem(HOST_STORAGE_KEY);
+      if (stored) return stored;
+    }
+    return DEFAULT_HOST;
+  });
   const error = useState<string | null>("camera-error", () => null);
   const loadingLibrary = useState<boolean>("camera-library-loading", () => false);
   /** True from a successful manual connect until a manual disconnect */
   const wantConnection = useState<boolean>("camera-want-connection", () => false);
   const retryAttempt = useState<number>("camera-retry-attempt", () => 0);
+
+  // Persisted so the home page can ship a bare Connect button: a user on a
+  // non-default gateway should not have to retype it every launch.
+  if (import.meta.client) {
+    watch(host, (value) => {
+      localStorage.setItem(HOST_STORAGE_KEY, value.trim());
+    });
+  }
 
   const isConnected = computed(() => status.value === "connected");
   const isBusy = computed(() => status.value === "connecting");

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -4,24 +4,33 @@ import type { NavigationMenuItem } from "@nuxt/ui";
 const { active } = useDownloads();
 const route = useRoute();
 
-const items = computed<NavigationMenuItem[]>(() => [
-  {
-    label: "Connect",
-    icon: "i-lucide-cable",
-    to: "/",
-    active: route.path === "/",
-  },
-  {
-    label: "Gallery",
-    icon: "i-lucide-images",
-    to: "/gallery",
-  },
-  {
-    label: "Downloads",
-    icon: "i-lucide-arrow-down-to-line",
-    to: "/downloads",
-    badge: active.value.length > 0 ? String(active.value.length) : undefined,
-  },
+const items = computed<NavigationMenuItem[][]>(() => [
+  [
+    {
+      label: "Connect",
+      icon: "i-lucide-cable",
+      to: "/",
+      active: route.path === "/",
+    },
+    {
+      label: "Gallery",
+      icon: "i-lucide-images",
+      to: "/gallery",
+    },
+    {
+      label: "Downloads",
+      icon: "i-lucide-arrow-down-to-line",
+      to: "/downloads",
+      badge: active.value.length > 0 ? String(active.value.length) : undefined,
+    },
+  ],
+  [
+    {
+      label: "Settings",
+      icon: "i-lucide-settings",
+      to: "/settings",
+    },
+  ],
 ]);
 </script>
 
@@ -47,7 +56,6 @@ const items = computed<NavigationMenuItem[]>(() => [
         <div class="flex w-full flex-col gap-3" :class="collapsed ? 'items-center' : ''">
           <UpdateBanner :collapsed="collapsed" />
           <CameraStatusChip :collapsed="collapsed" />
-          <ColorwayToggle :collapsed="collapsed" />
         </div>
       </template>
     </UDashboardSidebar>

--- a/app/pages/gallery.vue
+++ b/app/pages/gallery.vue
@@ -215,9 +215,16 @@ defineShortcuts({
         <UButton label="Go to Connect" icon="i-lucide-cable" to="/" />
       </div>
 
-      <div v-else-if="loadingLibrary && groups.length === 0" class="flex h-full flex-col items-center justify-center gap-3 text-center">
-        <UIcon name="i-lucide-loader-circle" class="size-7 animate-spin text-dimmed" />
-        <p class="text-sm text-muted">Reading the camera library</p>
+      <div v-else-if="loadingLibrary && groups.length === 0" class="space-y-8" aria-busy="true">
+        <section v-for="section in 2" :key="section">
+          <div class="mb-2.5 h-5 w-32 animate-pulse rounded bg-elevated" />
+          <div
+            class="grid gap-2"
+            :style="{ gridTemplateColumns: `repeat(auto-fill, minmax(${tileMin}px, 1fr))` }"
+          >
+            <div v-for="tile in 12" :key="tile" class="aspect-square animate-pulse rounded-lg bg-elevated" />
+          </div>
+        </section>
       </div>
 
       <div v-else-if="groups.length === 0" class="flex h-full flex-col items-center justify-center gap-4 text-center">
@@ -235,7 +242,7 @@ defineShortcuts({
 
       <div v-else class="space-y-8 pb-24">
         <section v-for="group in groups" :key="group.key" :aria-label="group.label">
-          <div class="group/day mb-2.5 flex items-baseline gap-3">
+          <div class="mb-2.5 flex items-baseline gap-3">
             <h2 class="text-sm font-semibold text-highlighted">{{ group.label }}</h2>
             <span class="font-mono text-xs text-muted tabular-nums">{{ group.items.length }}</span>
             <UButton
@@ -243,8 +250,6 @@ defineShortcuts({
               size="xs"
               color="neutral"
               variant="ghost"
-              class="opacity-0 transition-opacity focus-visible:opacity-100 group-hover/day:opacity-100"
-              :class="selectionActive ? 'opacity-100' : ''"
               @click="selectGroup(group.items.map((i) => i.id))"
             />
           </div>

--- a/app/pages/gallery.vue
+++ b/app/pages/gallery.vue
@@ -215,8 +215,14 @@ defineShortcuts({
         <UButton label="Go to Connect" icon="i-lucide-cable" to="/" />
       </div>
 
-      <div v-else-if="loadingLibrary && groups.length === 0" class="space-y-8" aria-busy="true">
-        <section v-for="section in 2" :key="section">
+      <div
+        v-else-if="loadingLibrary && groups.length === 0"
+        class="space-y-8"
+        role="status"
+        aria-busy="true"
+        aria-label="Reading the camera library"
+      >
+        <section v-for="section in 2" :key="section" aria-hidden="true">
           <div class="mb-2.5 h-5 w-32 animate-pulse rounded bg-elevated" />
           <div
             class="grid gap-2"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { info, library, host, error, isConnected, isBusy, available, connect, disconnect } = useCamera();
+const { info, error, isConnected, isBusy, available, connect, disconnect } = useCamera();
 
 useHead({ title: "Connect" });
 
@@ -16,23 +16,35 @@ watch(isConnected, (connected) => {
         <template #leading>
           <UDashboardSidebarCollapse />
         </template>
-        <template #right>
-          <UButton
-            v-if="isConnected"
-            label="Disconnect"
-            color="neutral"
-            variant="ghost"
-            icon="i-lucide-unplug"
-            @click="disconnect"
-          />
-        </template>
       </UDashboardNavbar>
     </template>
 
     <template #body>
       <div class="grid h-full grid-cols-1 gap-8 lg:grid-cols-2 lg:items-center">
         <div class="order-2 flex flex-col justify-center gap-6 lg:order-1 lg:pl-6">
-          <template v-if="!isConnected">
+          <template v-if="isConnected && info">
+            <div class="space-y-1.5">
+              <h1 class="text-3xl font-semibold tracking-tight text-highlighted">
+                {{ info.deviceName ?? "Luna Ultra" }}
+              </h1>
+              <p class="font-mono text-sm text-muted">{{ info.ssid ?? info.host }}</p>
+            </div>
+
+            <div class="flex max-w-md items-center gap-3">
+              <UButton size="xl" icon="i-lucide-images" label="Open gallery" to="/gallery" />
+              <UButton
+                class="ml-auto"
+                size="xl"
+                label="Disconnect"
+                icon="i-lucide-unplug"
+                color="neutral"
+                variant="ghost"
+                @click="disconnect"
+              />
+            </div>
+          </template>
+
+          <template v-else>
             <div class="space-y-3">
               <h1 class="text-3xl font-semibold tracking-tight text-highlighted lg:text-4xl">
                 Pair your Luna Ultra
@@ -44,89 +56,37 @@ watch(isConnected, (connected) => {
 
             <UAlert
               v-if="!available"
+              class="max-w-md"
               icon="i-lucide-monitor-down"
               color="warning"
               variant="subtle"
               title="Desktop app required"
-              description="Connecting to the camera needs the packaged Luna Ultra desktop app. Run it with bun run dev."
+              description="Connecting to the camera needs the packaged Luna Ultra desktop app."
             />
 
-            <form class="flex max-w-md flex-col gap-3" @submit.prevent="connect">
-              <UFormField label="Camera address" name="host">
-                <UInput
-                  v-model="host"
-                  placeholder="192.168.42.1"
-                  icon="i-lucide-router"
-                  :disabled="isBusy || !available"
-                  autocomplete="off"
-                  spellcheck="false"
-                  class="w-full font-mono"
-                />
-                <template #help>Default Luna Ultra Wi-Fi gateway. Include a port for the dev mock (127.0.0.1:18080).</template>
-              </UFormField>
+            <UAlert
+              v-if="error"
+              class="max-w-md"
+              icon="i-lucide-triangle-alert"
+              color="error"
+              variant="subtle"
+              :title="error"
+            >
+              <template #actions>
+                <UButton label="Open settings" size="xs" color="neutral" variant="outline" to="/settings" />
+              </template>
+            </UAlert>
 
-              <UAlert
-                v-if="error"
-                icon="i-lucide-triangle-alert"
-                color="error"
-                variant="subtle"
-                :title="error"
-              >
-                <template #description>
-                  <ul class="mt-1 list-disc space-y-0.5 pl-4 text-xs">
-                    <li>Make sure your computer is joined to the camera's Wi-Fi network.</li>
-                    <li>Confirm the address matches the camera's gateway (default <span class="font-mono">192.168.42.1</span>).</li>
-                    <li>
-                      On macOS, allow <span class="font-medium">Luna Ultra Desktop</span> under System Settings ›
-                      Privacy &amp; Security › Local Network.
-                    </li>
-                  </ul>
-                </template>
-              </UAlert>
-
-              <div class="flex items-center gap-3">
-                <UButton
-                  type="submit"
-                  size="xl"
-                  icon="i-lucide-cable"
-                  :label="isBusy ? 'Connecting' : 'Connect camera'"
-                  :loading="isBusy"
-                  :disabled="!available"
-                />
-                <UButton size="xl" label="View downloads" color="neutral" variant="ghost" to="/downloads" />
-              </div>
-            </form>
-          </template>
-
-          <template v-else-if="info">
-            <div class="space-y-1.5">
-              <h1 class="text-3xl font-semibold tracking-tight text-highlighted">
-                {{ info.deviceName ?? "Luna Ultra" }}
-              </h1>
-              <p class="font-mono text-sm text-muted">{{ info.ssid ?? info.host }}</p>
-            </div>
-
-            <dl class="grid max-w-md grid-cols-2 gap-x-8 gap-y-4 text-sm">
-              <div>
-                <dt class="text-muted">Address</dt>
-                <dd class="mt-0.5 font-mono text-default">{{ info.host }}</dd>
-              </div>
-              <div v-if="info.serial">
-                <dt class="text-muted">Serial</dt>
-                <dd class="mt-0.5 font-mono text-default">{{ info.serial }}</dd>
-              </div>
-              <div v-if="info.firmware">
-                <dt class="text-muted">Firmware</dt>
-                <dd class="mt-0.5 font-mono text-default">{{ info.firmware }}</dd>
-              </div>
-              <div>
-                <dt class="text-muted">Media</dt>
-                <dd class="mt-0.5 font-mono text-default">{{ library.length }} files</dd>
-              </div>
-            </dl>
-
-            <div class="flex items-center gap-3">
-              <UButton size="xl" icon="i-lucide-images" label="Open gallery" to="/gallery" />
+            <div class="flex max-w-md items-center gap-3">
+              <UButton
+                size="xl"
+                icon="i-lucide-cable"
+                :label="isBusy ? 'Connecting' : 'Connect camera'"
+                :loading="isBusy"
+                :disabled="!available"
+                @click="connect"
+              />
+              <UButton size="xl" label="View downloads" color="neutral" variant="ghost" to="/downloads" />
             </div>
           </template>
         </div>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+const { info, library, host, error, isConnected, isBusy, available, connect, disconnect } = useCamera();
+const { reset: resetWatermark } = useWatermarkSettings();
+
+useHead({ title: "Settings" });
+</script>
+
+<template>
+  <UDashboardPanel id="settings">
+    <template #header>
+      <UDashboardNavbar title="Settings">
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <div class="mx-auto w-full max-w-2xl space-y-10 pb-12">
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Camera</h2>
+            <p class="text-sm text-muted">Where the app looks for your Luna Ultra.</p>
+          </div>
+
+          <UAlert
+            v-if="!available"
+            icon="i-lucide-monitor-down"
+            color="warning"
+            variant="subtle"
+            title="Desktop app required"
+            description="Connecting to the camera needs the packaged Luna Ultra desktop app."
+          />
+
+          <UFormField label="Camera address" name="host">
+            <UInput
+              v-model="host"
+              placeholder="192.168.42.1"
+              icon="i-lucide-router"
+              :disabled="isBusy || !available"
+              autocomplete="off"
+              spellcheck="false"
+              class="w-full font-mono"
+            />
+            <template #help>
+              Default Luna Ultra Wi-Fi gateway. Include a port for the dev mock (127.0.0.1:18080).
+            </template>
+          </UFormField>
+
+          <UAlert v-if="error" icon="i-lucide-triangle-alert" color="error" variant="subtle" :title="error">
+            <template #description>
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-xs">
+                <li>Make sure your computer is joined to the camera's Wi-Fi network.</li>
+                <li>Confirm the address matches the camera's gateway (default <span class="font-mono">192.168.42.1</span>).</li>
+                <li>
+                  On macOS, allow <span class="font-medium">Luna Ultra Desktop</span> under System Settings &rsaquo;
+                  Privacy &amp; Security &rsaquo; Local Network.
+                </li>
+              </ul>
+            </template>
+          </UAlert>
+
+          <dl v-if="isConnected && info" class="grid grid-cols-2 gap-x-8 gap-y-4 border-t border-default pt-4 text-sm">
+            <div>
+              <dt class="text-muted">Device</dt>
+              <dd class="mt-0.5 text-default">{{ info.deviceName ?? "Luna Ultra" }}</dd>
+            </div>
+            <div>
+              <dt class="text-muted">Address</dt>
+              <dd class="mt-0.5 font-mono tabular-nums text-default">{{ info.host }}</dd>
+            </div>
+            <div v-if="info.serial">
+              <dt class="text-muted">Serial</dt>
+              <dd class="mt-0.5 font-mono text-default">{{ info.serial }}</dd>
+            </div>
+            <div v-if="info.firmware">
+              <dt class="text-muted">Firmware</dt>
+              <dd class="mt-0.5 font-mono text-default">{{ info.firmware }}</dd>
+            </div>
+            <div>
+              <dt class="text-muted">Media</dt>
+              <dd class="mt-0.5 font-mono tabular-nums text-default">{{ library.length }} files</dd>
+            </div>
+          </dl>
+
+          <div class="flex justify-end border-t border-default pt-4">
+            <UButton
+              v-if="isConnected"
+              label="Disconnect"
+              icon="i-lucide-unplug"
+              color="neutral"
+              variant="outline"
+              @click="disconnect"
+            />
+            <UButton
+              v-else
+              label="Connect camera"
+              icon="i-lucide-cable"
+              :loading="isBusy"
+              :disabled="!available"
+              @click="connect"
+            />
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Watermark</h2>
+            <p class="text-sm text-muted">Applied to photos as they download. Videos transfer untouched.</p>
+          </div>
+
+          <WatermarkSettingsForm />
+
+          <div class="flex justify-end border-t border-default pt-4">
+            <UButton label="Reset to default" icon="i-lucide-rotate-ccw" color="neutral" variant="ghost" @click="resetWatermark" />
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Appearance</h2>
+            <p class="text-sm text-muted">Colourway for the app window.</p>
+          </div>
+
+          <ColorwayToggle />
+        </section>
+      </div>
+    </template>
+  </UDashboardPanel>
+</template>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -123,7 +123,10 @@ useHead({ title: "Settings" });
             <p class="text-sm text-muted">Colourway for the app window.</p>
           </div>
 
-          <ColorwayToggle />
+          <!-- Constrained here only: the sidebar still wants the full-width toggle. -->
+          <div class="max-w-xs">
+            <ColorwayToggle />
+          </div>
         </section>
       </div>
     </template>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -37,13 +37,14 @@ useHead({ title: "Settings" });
               v-model="host"
               placeholder="192.168.42.1"
               icon="i-lucide-router"
-              :disabled="isBusy || !available"
+              :disabled="isBusy || isConnected || !available"
               autocomplete="off"
               spellcheck="false"
               class="w-full font-mono"
             />
             <template #help>
               Default Luna Ultra Wi-Fi gateway. Include a port for the dev mock (127.0.0.1:18080).
+              <template v-if="isConnected"> Disconnect first to change the address.</template>
             </template>
           </UFormField>
 

--- a/app/utils/cameraHealth.ts
+++ b/app/utils/cameraHealth.ts
@@ -1,0 +1,39 @@
+/**
+ * Watches for the camera going silent mid-session. Only transport failures
+ * count: a thrown fetch (timeout, refused connection, Wi-Fi gone). Any
+ * completed HTTP response, including a 404 for a missing file, proves the
+ * camera is answering and resets the count, so one bad file can never end a
+ * working session.
+ */
+export const FAILURE_THRESHOLD = 3;
+
+let consecutiveFailures = 0;
+let onDeadCallback: (() => void) | null = null;
+
+/** Start counting. Replaces any previous callback and resets the count. */
+export function armCameraHealth(onDead: () => void): void {
+  consecutiveFailures = 0;
+  onDeadCallback = onDead;
+}
+
+/** Stop counting. Reports become no-ops until armed again. */
+export function disarmCameraHealth(): void {
+  consecutiveFailures = 0;
+  onDeadCallback = null;
+}
+
+export function reportCameraSuccess(): void {
+  if (!onDeadCallback) return;
+  consecutiveFailures = 0;
+}
+
+export function reportCameraFailure(): void {
+  if (!onDeadCallback) return;
+  consecutiveFailures += 1;
+  if (consecutiveFailures < FAILURE_THRESHOLD) return;
+  // Disarm before invoking so a burst of concurrent in-flight failures
+  // cannot fire the callback more than once.
+  const callback = onDeadCallback;
+  disarmCameraHealth();
+  callback();
+}

--- a/app/utils/cameraHealth.ts
+++ b/app/utils/cameraHealth.ts
@@ -4,22 +4,41 @@
  * completed HTTP response, including a 404 for a missing file, proves the
  * camera is answering and resets the count, so one bad file can never end a
  * working session.
+ *
+ * Reaching the threshold is not proof on its own: a single large download that
+ * retries and drops three times can get there while the camera is perfectly
+ * healthy. So the threshold only triggers a cheap probe request, and the
+ * session is dropped only when that probe also fails.
+ *
+ * The probe is injected rather than imported so this module stays pure: no
+ * Vue, no Nuxt, no fetch, unit-testable under a plain node environment.
  */
 export const FAILURE_THRESHOLD = 3;
 
 let consecutiveFailures = 0;
 let onDeadCallback: (() => void) | null = null;
+let probeCamera: (() => Promise<boolean>) | null = null;
+let probeInFlight = false;
 
-/** Start counting. Replaces any previous callback and resets the count. */
-export function armCameraHealth(onDead: () => void): void {
+/**
+ * Start counting. Replaces any previous callback and resets the count.
+ *
+ * @param onDead Called once when the camera is confirmed gone.
+ * @param probe Cheap liveness check; resolves true when the camera answered.
+ */
+export function armCameraHealth(onDead: () => void, probe: () => Promise<boolean>): void {
   consecutiveFailures = 0;
+  probeInFlight = false;
   onDeadCallback = onDead;
+  probeCamera = probe;
 }
 
 /** Stop counting. Reports become no-ops until armed again. */
 export function disarmCameraHealth(): void {
   consecutiveFailures = 0;
+  probeInFlight = false;
   onDeadCallback = null;
+  probeCamera = null;
 }
 
 export function reportCameraSuccess(): void {
@@ -28,12 +47,39 @@ export function reportCameraSuccess(): void {
 }
 
 export function reportCameraFailure(): void {
-  if (!onDeadCallback) return;
+  // While a probe is open the verdict is already being decided; further
+  // failures must not open a second one.
+  if (!onDeadCallback || probeInFlight) return;
   consecutiveFailures += 1;
   if (consecutiveFailures < FAILURE_THRESHOLD) return;
-  // Disarm before invoking so a burst of concurrent in-flight failures
-  // cannot fire the callback more than once.
+  void runProbe();
+}
+
+async function runProbe(): Promise<void> {
+  const probe = probeCamera;
   const callback = onDeadCallback;
+  if (!probe || !callback) return;
+
+  probeInFlight = true;
+  let alive = false;
+  try {
+    alive = await probe();
+  } catch {
+    alive = false;
+  }
+
+  // The session may have been torn down or re-armed while the probe was open;
+  // in that case this verdict is stale and must not fire anything.
+  if (onDeadCallback !== callback) return;
+  probeInFlight = false;
+
+  if (alive) {
+    // The camera answered, so the failures were the transfer's fault.
+    consecutiveFailures = 0;
+    return;
+  }
+
+  // Disarm before invoking so nothing can fire the callback a second time.
   disarmCameraHealth();
   callback();
 }

--- a/app/utils/lunaClient.ts
+++ b/app/utils/lunaClient.ts
@@ -1,6 +1,7 @@
 import type { CameraInfo, MediaItem, MediaStorage } from "~/types/media";
 import { isTauri } from "~/utils/saveFile";
 import { extractCameraSubdirs, parseLunaIndex } from "~/utils/lunaIndex";
+import { reportCameraFailure, reportCameraSuccess } from "~/utils/cameraHealth";
 
 /** Storage roots the Luna Ultra exposes over HTTP, default first. */
 const STORAGE_ROOTS: Array<{ path: string; id: MediaStorage }> = [
@@ -29,13 +30,27 @@ async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): 
   return invoke<T>(command, args);
 }
 
-/** Fetch a camera URL. Uses the Tauri HTTP plugin (bypasses CORS/mixed-content) when packaged. */
+/**
+ * Fetch a camera URL. Uses the Tauri HTTP plugin (bypasses CORS/mixed-content)
+ * when packaged. Every camera request flows through here, so this is also
+ * where the health counter is fed: a completed response of any status means
+ * the camera answered, a thrown request means it did not.
+ */
 export async function cameraFetch(url: string, init?: RequestInit): Promise<Response> {
-  if (isTauri()) {
-    const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
-    return tauriFetch(url, init);
+  try {
+    let response: Response;
+    if (isTauri()) {
+      const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+      response = await tauriFetch(url, init);
+    } else {
+      response = await fetch(url, init);
+    }
+    reportCameraSuccess();
+    return response;
+  } catch (error) {
+    reportCameraFailure();
+    throw error;
   }
-  return fetch(url, init);
 }
 
 function toInfo(raw: RawDeviceInfo): CameraInfo {

--- a/app/utils/lunaClient.ts
+++ b/app/utils/lunaClient.ts
@@ -38,18 +38,37 @@ async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): 
  */
 export async function cameraFetch(url: string, init?: RequestInit): Promise<Response> {
   try {
-    let response: Response;
-    if (isTauri()) {
-      const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
-      response = await tauriFetch(url, init);
-    } else {
-      response = await fetch(url, init);
-    }
+    const response = await rawCameraFetch(url, init);
     reportCameraSuccess();
     return response;
   } catch (error) {
     reportCameraFailure();
     throw error;
+  }
+}
+
+/** The transport on its own, with no health reporting attached. */
+async function rawCameraFetch(url: string, init?: RequestInit): Promise<Response> {
+  if (isTauri()) {
+    const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+    return tauriFetch(url, init);
+  }
+  return fetch(url, init);
+}
+
+/**
+ * Cheap liveness check used by the health detector: ask for the storage root
+ * listing and treat any completed response, whatever the status, as proof the
+ * camera answered. Deliberately bypasses `cameraFetch` so the probe cannot
+ * feed the very counter that triggered it.
+ */
+export async function probeCamera(host: string): Promise<boolean> {
+  const root = STORAGE_ROOTS[0]!;
+  try {
+    await rawCameraFetch(baseUrl(host, root.path), { headers: { "Cache-Control": "no-cache" } });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/docs/superpowers/plans/2026-07-22-settings-page-and-auto-disconnect.md
+++ b/docs/superpowers/plans/2026-07-22-settings-page-and-auto-disconnect.md
@@ -1,0 +1,1068 @@
+# Settings Page, Auto-Disconnect, and Layout Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move camera configuration off the home page into a dedicated `/settings` route, force-disconnect the camera after three consecutive transport failures, and fix layout and button placement across the app.
+
+**Architecture:** A framework-free `cameraHealth` module counts consecutive transport failures and is fed from the single `cameraFetch` chokepoint in `lunaClient.ts`. `useCamera` arms it on connect and runs a hard disconnect when it fires. The UI work is additive: a new page, a component extraction, and in-place edits to existing templates. No Rust changes, no new dependencies.
+
+**Tech Stack:** Nuxt 4 (`ssr: false`), Vue 3 script-setup, Nuxt UI v4, Tauri 2, Vitest, oxlint, Bun.
+
+## Global Constraints
+
+- Never use `any` to fix a type error. Use `as unknown as X` only when strictly necessary.
+- Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`).
+- Tests first, then implementation.
+- No new runtime dependencies.
+- No changes under `src-tauri/`.
+- No route renames. The only new route is `/settings`.
+- No font, palette, or design-token changes. Use the existing Nuxt UI semantic classes (`text-muted`, `text-highlighted`, `text-dimmed`, `bg-elevated`, `border-default`).
+- Vitest runs with `environment: "node"`. There is no `localStorage`, no `window`, and no Nuxt auto-import inside tests. Only test plain modules under `app/utils/`.
+- Icons come from `i-lucide-*`, matching the rest of the app.
+- No em-dash characters in user-visible strings.
+- Run `bun run lint` before every commit.
+
+## File Structure
+
+| Path | Responsibility |
+| --- | --- |
+| `app/utils/cameraHealth.ts` | NEW. Consecutive-failure counter and armed callback. Pure module, no Vue. |
+| `tests/cameraHealth.test.ts` | NEW. Unit tests for the counter. |
+| `app/utils/lunaClient.ts` | MODIFY. `cameraFetch` reports success/failure to `cameraHealth`. |
+| `app/composables/useCamera.ts` | MODIFY. Arm/disarm the detector, add `forceDisconnect`, persist the host. |
+| `app/components/WatermarkSettingsForm.vue` | NEW. Watermark controls extracted from the download modal. |
+| `app/components/DownloadOptionsModal.vue` | MODIFY. Consumes the extracted form. |
+| `app/pages/settings.vue` | NEW. Camera, Watermark and Appearance sections. |
+| `app/layouts/default.vue` | MODIFY. Settings nav entry, `ColorwayToggle` removed from the footer. |
+| `app/components/CameraStatusChip.vue` | MODIFY. Becomes a link to `/settings`. |
+| `app/pages/index.vue` | MODIFY. Reduced to connect/disconnect. |
+| `app/components/MediaPreview.vue` | MODIFY. Header action row and arrow insets. |
+| `app/pages/gallery.vue` | MODIFY. "Select day" visibility, skeleton loading state. |
+
+**Not in this plan:** `app/pages/downloads.vue`. The spec asked for an empty state and an inline retry on failed rows. Both already exist (`downloads.vue:31-41` and `downloads.vue:87-95`). No work needed.
+
+---
+
+### Task 1: Camera health counter
+
+**Files:**
+- Create: `app/utils/cameraHealth.ts`
+- Test: `tests/cameraHealth.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `FAILURE_THRESHOLD: number` (value `3`)
+  - `armCameraHealth(onDead: () => void): void`
+  - `disarmCameraHealth(): void`
+  - `reportCameraSuccess(): void`
+  - `reportCameraFailure(): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cameraHealth.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FAILURE_THRESHOLD,
+  armCameraHealth,
+  disarmCameraHealth,
+  reportCameraFailure,
+  reportCameraSuccess,
+} from "~/utils/cameraHealth";
+
+describe("cameraHealth", () => {
+  beforeEach(() => {
+    disarmCameraHealth();
+  });
+
+  it("fires once after three consecutive failures", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire before the threshold", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD - 1; i++) reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("resets the count on any success", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    reportCameraFailure();
+    reportCameraSuccess();
+    reportCameraFailure();
+    reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("ignores failures while disarmed", () => {
+    const onDead = vi.fn();
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    armCameraHealth(onDead);
+    reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("does not fire again after it has fired", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD + 3; i++) reportCameraFailure();
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the callback when armed twice", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    armCameraHealth(first);
+    reportCameraFailure();
+    armCameraHealth(second);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun run vitest run tests/cameraHealth.test.ts`
+Expected: FAIL, cannot resolve `~/utils/cameraHealth`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/utils/cameraHealth.ts`:
+
+```ts
+/**
+ * Watches for the camera going silent mid-session. Only transport failures
+ * count: a thrown fetch (timeout, refused connection, Wi-Fi gone). Any
+ * completed HTTP response, including a 404 for a missing file, proves the
+ * camera is answering and resets the count, so one bad file can never end a
+ * working session.
+ */
+export const FAILURE_THRESHOLD = 3;
+
+let consecutiveFailures = 0;
+let onDeadCallback: (() => void) | null = null;
+
+/** Start counting. Replaces any previous callback and resets the count. */
+export function armCameraHealth(onDead: () => void): void {
+  consecutiveFailures = 0;
+  onDeadCallback = onDead;
+}
+
+/** Stop counting. Reports become no-ops until armed again. */
+export function disarmCameraHealth(): void {
+  consecutiveFailures = 0;
+  onDeadCallback = null;
+}
+
+export function reportCameraSuccess(): void {
+  if (!onDeadCallback) return;
+  consecutiveFailures = 0;
+}
+
+export function reportCameraFailure(): void {
+  if (!onDeadCallback) return;
+  consecutiveFailures += 1;
+  if (consecutiveFailures < FAILURE_THRESHOLD) return;
+  // Disarm before invoking so a burst of concurrent in-flight failures
+  // cannot fire the callback more than once.
+  const callback = onDeadCallback;
+  disarmCameraHealth();
+  callback();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun run vitest run tests/cameraHealth.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+bun run lint
+git add app/utils/cameraHealth.ts tests/cameraHealth.test.ts
+git commit -m "feat: add camera health failure counter"
+```
+
+---
+
+### Task 2: Feed the counter from cameraFetch and hard-disconnect
+
+**Files:**
+- Modify: `app/utils/lunaClient.ts:32-39`
+- Modify: `app/composables/useCamera.ts`
+
+**Interfaces:**
+- Consumes: `armCameraHealth`, `disarmCameraHealth`, `reportCameraSuccess`, `reportCameraFailure`, `FAILURE_THRESHOLD` from Task 1.
+- Produces: `useCamera()` gains no new public members. `disconnect()` keeps its existing signature `(): Promise<void>`.
+
+- [ ] **Step 1: Report success and failure from `cameraFetch`**
+
+In `app/utils/lunaClient.ts`, add the import beside the existing ones:
+
+```ts
+import { reportCameraFailure, reportCameraSuccess } from "~/utils/cameraHealth";
+```
+
+Replace the whole `cameraFetch` function:
+
+```ts
+/**
+ * Fetch a camera URL. Uses the Tauri HTTP plugin (bypasses CORS/mixed-content)
+ * when packaged. Every camera request flows through here, so this is also
+ * where the health counter is fed: a completed response of any status means
+ * the camera answered, a thrown request means it did not.
+ */
+export async function cameraFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    let response: Response;
+    if (isTauri()) {
+      const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+      response = await tauriFetch(url, init);
+    } else {
+      response = await fetch(url, init);
+    }
+    reportCameraSuccess();
+    return response;
+  } catch (error) {
+    reportCameraFailure();
+    throw error;
+  }
+}
+```
+
+- [ ] **Step 2: Arm the detector and add the hard disconnect**
+
+In `app/composables/useCamera.ts`, add the import beside the existing `lunaClient` import:
+
+```ts
+import { armCameraHealth, disarmCameraHealth, FAILURE_THRESHOLD } from "~/utils/cameraHealth";
+```
+
+Replace the existing `disconnect` function with these two functions:
+
+```ts
+  /**
+   * Tear down the session without touching `wantConnection`. Shared by the
+   * user-initiated disconnect and the health-detector disconnect.
+   */
+  async function teardown() {
+    clearRetryTimer();
+    disarmCameraHealth();
+    await lunaClient.disconnect();
+    status.value = "disconnected";
+    info.value = null;
+    library.value = [];
+  }
+
+  async function disconnect() {
+    wantConnection.value = false;
+    await teardown();
+    error.value = null;
+  }
+
+  /**
+   * The camera stopped answering. Drop the session and leave it dropped:
+   * clearing `wantConnection` keeps the backoff reconnect loop dormant so it
+   * cannot immediately undo this. The user reconnects deliberately.
+   */
+  async function forceDisconnect() {
+    wantConnection.value = false;
+    await teardown();
+    error.value = `Lost contact with the camera. Disconnected after ${FAILURE_THRESHOLD} failed requests.`;
+  }
+```
+
+In `connect()`, arm the detector immediately after `wantConnection.value = true;`:
+
+```ts
+      wantConnection.value = true;
+      armCameraHealth(() => {
+        void forceDisconnect();
+      });
+```
+
+In `tryReconnect()`, re-arm after a successful reconnect. Replace `retryAttempt.value = 0;` in the `try` block (the one directly after `error.value = null;`) with:
+
+```ts
+      retryAttempt.value = 0;
+      armCameraHealth(() => {
+        void forceDisconnect();
+      });
+```
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `bun run vitest run`
+Expected: PASS. All existing suites stay green; `cameraFetch`'s success path is unchanged.
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/lunaClient.ts app/composables/useCamera.ts
+git commit -m "feat: disconnect the camera after three failed requests"
+```
+
+---
+
+### Task 3: Persist the camera host
+
+**Files:**
+- Modify: `app/composables/useCamera.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `useCamera().host` is a `Ref<string>` restored from and written to `localStorage` under `luna-camera-host`. Later tasks bind an input straight to it.
+
+- [ ] **Step 1: Read the stored host on first use**
+
+In `app/composables/useCamera.ts`, add the storage key beside `DEFAULT_HOST`:
+
+```ts
+const DEFAULT_HOST = "192.168.42.1";
+const HOST_STORAGE_KEY = "luna-camera-host";
+```
+
+Replace the `host` state initialiser:
+
+```ts
+  const host = useState<string>("camera-host", () => {
+    if (import.meta.client) {
+      const stored = localStorage.getItem(HOST_STORAGE_KEY);
+      if (stored) return stored;
+    }
+    return DEFAULT_HOST;
+  });
+```
+
+- [ ] **Step 2: Write it back on change**
+
+Directly after the `const retryAttempt = ...` line, add:
+
+```ts
+  // Persisted so the home page can ship a bare Connect button: a user on a
+  // non-default gateway should not have to retype it every launch.
+  if (import.meta.client) {
+    watch(host, (value) => {
+      localStorage.setItem(HOST_STORAGE_KEY, value.trim());
+    });
+  }
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/composables/useCamera.ts
+git commit -m "feat: persist the camera host across launches"
+```
+
+---
+
+### Task 4: Extract the watermark form
+
+**Files:**
+- Create: `app/components/WatermarkSettingsForm.vue`
+- Modify: `app/components/DownloadOptionsModal.vue`
+
+**Interfaces:**
+- Consumes: `useWatermarkSettings()` (existing).
+- Produces: `<WatermarkSettingsForm :preview-src="string | undefined" />`. It owns the enable switch, the preview and the position picker. It renders no title, no footer and no buttons.
+
+- [ ] **Step 1: Create the component**
+
+Create `app/components/WatermarkSettingsForm.vue`:
+
+```vue
+<script setup lang="ts">
+import { WATERMARK_POSITIONS, type WatermarkPosition } from "~/utils/watermark";
+
+defineProps<{ previewSrc?: string }>();
+
+const { settings } = useWatermarkSettings();
+
+const positionLabels: Record<WatermarkPosition, string> = {
+  "top-left": "Top left",
+  "top-right": "Top right",
+  "bottom-left": "Bottom left",
+  "bottom-center": "Bottom center",
+  "bottom-right": "Bottom right",
+};
+
+const anchorClasses: Record<WatermarkPosition, string> = {
+  "top-left": "left-2 top-2",
+  "top-right": "right-2 top-2",
+  "bottom-left": "bottom-2 left-2",
+  "bottom-center": "bottom-2 left-1/2 -translate-x-1/2",
+  "bottom-right": "bottom-2 right-2",
+};
+</script>
+
+<template>
+  <div class="space-y-5">
+    <USwitch
+      v-model="settings.enabled"
+      label="Apply Luna Ultra watermark"
+      description="The official watermark is rendered into photos. Videos transfer untouched."
+    />
+
+    <div v-if="settings.enabled" class="grid grid-cols-[1fr_auto] items-start gap-4">
+      <WatermarkCanvas :src="previewSrc" />
+      <UFormField label="Position" :help="positionLabels[settings.position]">
+        <div class="relative h-20 w-32 rounded-lg border border-default bg-muted">
+          <button
+            v-for="position in WATERMARK_POSITIONS"
+            :key="position"
+            type="button"
+            class="absolute flex size-6 cursor-pointer items-center justify-center rounded-md border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :class="[
+              anchorClasses[position],
+              settings.position === position
+                ? 'border-transparent bg-primary text-inverted'
+                : 'border-default bg-elevated text-muted hover:border-accented hover:text-default',
+            ]"
+            :aria-label="positionLabels[position]"
+            :aria-pressed="settings.position === position"
+            @click="settings.position = position"
+          >
+            <span class="block size-1.5 rounded-[2px] bg-current" />
+          </button>
+        </div>
+      </UFormField>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Consume it from the modal**
+
+Replace the entire contents of `app/components/DownloadOptionsModal.vue`:
+
+```vue
+<script setup lang="ts">
+import type { MediaItem } from "~/types/media";
+
+const props = defineProps<{ items: MediaItem[] }>();
+
+const emit = defineEmits<{ close: [confirmed: boolean] }>();
+
+const photos = computed(() => props.items.filter((item) => item.type === "photo"));
+const videos = computed(() => props.items.filter((item) => item.type === "video"));
+const previewSrc = computed(() => photos.value[0]?.srcUrl);
+
+const summary = computed(() => {
+  const parts: string[] = [];
+  if (photos.value.length > 0) parts.push(`${photos.value.length} ${photos.value.length === 1 ? "photo" : "photos"}`);
+  if (videos.value.length > 0) parts.push(`${videos.value.length} ${videos.value.length === 1 ? "video" : "videos"}`);
+  return parts.join(" and ");
+});
+</script>
+
+<template>
+  <UModal
+    :close="{ onClick: () => emit('close', false) }"
+    :title="`Download ${summary}`"
+    description="Files save to the Luna Ultra folder in Downloads."
+    :ui="{ footer: 'justify-end' }"
+  >
+    <template #body>
+      <WatermarkSettingsForm v-if="photos.length > 0" :preview-src="previewSrc" />
+      <p v-else class="text-sm text-muted">
+        Videos transfer untouched. Watermarking currently applies to photos only.
+      </p>
+    </template>
+
+    <template #footer>
+      <UButton label="Cancel" color="neutral" variant="outline" @click="emit('close', false)" />
+      <UButton
+        :label="items.length === 1 ? 'Download' : `Download ${items.length} files`"
+        icon="i-lucide-arrow-down-to-line"
+        @click="emit('close', true)"
+      />
+    </template>
+  </UModal>
+</template>
+```
+
+- [ ] **Step 3: Verify the modal in the app**
+
+Run: `bun run ui:dev`, open the gallery against the mock server (`luna_mock_server`), select a photo and press Download.
+Expected: the modal looks and behaves exactly as before. The position picker now shows a focus ring when tabbed to.
+
+- [ ] **Step 4: Typecheck, lint and commit**
+
+```bash
+bun run typecheck && bun run lint
+git add app/components/WatermarkSettingsForm.vue app/components/DownloadOptionsModal.vue
+git commit -m "refactor: extract WatermarkSettingsForm from the download modal"
+```
+
+---
+
+### Task 5: Settings page and navigation
+
+**Files:**
+- Create: `app/pages/settings.vue`
+- Modify: `app/layouts/default.vue`
+- Modify: `app/components/CameraStatusChip.vue`
+
+**Interfaces:**
+- Consumes: `useCamera()` (`info`, `library`, `host`, `error`, `isConnected`, `isBusy`, `available`, `connect`, `disconnect`), `useWatermarkSettings()` (`reset`), `WatermarkSettingsForm` from Task 4, `ColorwayToggle` (existing).
+- Produces: the `/settings` route.
+
+- [ ] **Step 1: Create the page**
+
+Create `app/pages/settings.vue`:
+
+```vue
+<script setup lang="ts">
+const { info, library, host, error, isConnected, isBusy, available, connect, disconnect } = useCamera();
+const { reset: resetWatermark } = useWatermarkSettings();
+
+useHead({ title: "Settings" });
+</script>
+
+<template>
+  <UDashboardPanel id="settings">
+    <template #header>
+      <UDashboardNavbar title="Settings">
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <div class="mx-auto w-full max-w-2xl space-y-10 pb-12">
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Camera</h2>
+            <p class="text-sm text-muted">Where the app looks for your Luna Ultra.</p>
+          </div>
+
+          <UAlert
+            v-if="!available"
+            icon="i-lucide-monitor-down"
+            color="warning"
+            variant="subtle"
+            title="Desktop app required"
+            description="Connecting to the camera needs the packaged Luna Ultra desktop app."
+          />
+
+          <UFormField label="Camera address" name="host">
+            <UInput
+              v-model="host"
+              placeholder="192.168.42.1"
+              icon="i-lucide-router"
+              :disabled="isBusy || !available"
+              autocomplete="off"
+              spellcheck="false"
+              class="w-full font-mono"
+            />
+            <template #help>
+              Default Luna Ultra Wi-Fi gateway. Include a port for the dev mock (127.0.0.1:18080).
+            </template>
+          </UFormField>
+
+          <UAlert v-if="error" icon="i-lucide-triangle-alert" color="error" variant="subtle" :title="error">
+            <template #description>
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-xs">
+                <li>Make sure your computer is joined to the camera's Wi-Fi network.</li>
+                <li>Confirm the address matches the camera's gateway (default <span class="font-mono">192.168.42.1</span>).</li>
+                <li>
+                  On macOS, allow <span class="font-medium">Luna Ultra Desktop</span> under System Settings &rsaquo;
+                  Privacy &amp; Security &rsaquo; Local Network.
+                </li>
+              </ul>
+            </template>
+          </UAlert>
+
+          <dl v-if="isConnected && info" class="grid grid-cols-2 gap-x-8 gap-y-4 border-t border-default pt-4 text-sm">
+            <div>
+              <dt class="text-muted">Device</dt>
+              <dd class="mt-0.5 text-default">{{ info.deviceName ?? "Luna Ultra" }}</dd>
+            </div>
+            <div>
+              <dt class="text-muted">Address</dt>
+              <dd class="mt-0.5 font-mono tabular-nums text-default">{{ info.host }}</dd>
+            </div>
+            <div v-if="info.serial">
+              <dt class="text-muted">Serial</dt>
+              <dd class="mt-0.5 font-mono text-default">{{ info.serial }}</dd>
+            </div>
+            <div v-if="info.firmware">
+              <dt class="text-muted">Firmware</dt>
+              <dd class="mt-0.5 font-mono text-default">{{ info.firmware }}</dd>
+            </div>
+            <div>
+              <dt class="text-muted">Media</dt>
+              <dd class="mt-0.5 font-mono tabular-nums text-default">{{ library.length }} files</dd>
+            </div>
+          </dl>
+
+          <div class="flex justify-end border-t border-default pt-4">
+            <UButton
+              v-if="isConnected"
+              label="Disconnect"
+              icon="i-lucide-unplug"
+              color="neutral"
+              variant="outline"
+              @click="disconnect"
+            />
+            <UButton
+              v-else
+              label="Connect camera"
+              icon="i-lucide-cable"
+              :loading="isBusy"
+              :disabled="!available"
+              @click="connect"
+            />
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Watermark</h2>
+            <p class="text-sm text-muted">Applied to photos as they download. Videos transfer untouched.</p>
+          </div>
+
+          <WatermarkSettingsForm />
+
+          <div class="flex justify-end border-t border-default pt-4">
+            <UButton label="Reset to default" icon="i-lucide-rotate-ccw" color="neutral" variant="ghost" @click="resetWatermark" />
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <div class="space-y-1">
+            <h2 class="text-sm font-semibold text-highlighted">Appearance</h2>
+            <p class="text-sm text-muted">Colourway for the app window.</p>
+          </div>
+
+          <ColorwayToggle />
+        </section>
+      </div>
+    </template>
+  </UDashboardPanel>
+</template>
+```
+
+- [ ] **Step 2: Add the nav entry and drop the footer toggle**
+
+In `app/layouts/default.vue`, split the nav into two groups. Replace the `items` computed:
+
+```ts
+const items = computed<NavigationMenuItem[][]>(() => [
+  [
+    {
+      label: "Connect",
+      icon: "i-lucide-cable",
+      to: "/",
+      active: route.path === "/",
+    },
+    {
+      label: "Gallery",
+      icon: "i-lucide-images",
+      to: "/gallery",
+    },
+    {
+      label: "Downloads",
+      icon: "i-lucide-arrow-down-to-line",
+      to: "/downloads",
+      badge: active.value.length > 0 ? String(active.value.length) : undefined,
+    },
+  ],
+  [
+    {
+      label: "Settings",
+      icon: "i-lucide-settings",
+      to: "/settings",
+    },
+  ],
+]);
+```
+
+`UNavigationMenu` renders a nested array as separated groups, which is what puts Settings below a divider.
+
+Then remove `ColorwayToggle` from the sidebar footer. Replace the `#footer` template:
+
+```vue
+      <template #footer="{ collapsed }">
+        <div class="flex w-full flex-col gap-3" :class="collapsed ? 'items-center' : ''">
+          <UpdateBanner :collapsed="collapsed" />
+          <CameraStatusChip :collapsed="collapsed" />
+        </div>
+      </template>
+```
+
+- [ ] **Step 3: Make the status chip a link**
+
+In `app/components/CameraStatusChip.vue`, wrap the badge in a `NuxtLink`. Replace the template:
+
+```vue
+<template>
+  <UTooltip :text="tooltip">
+    <NuxtLink
+      to="/settings"
+      class="block rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      :class="collapsed ? '' : 'w-full'"
+      aria-label="Camera settings"
+    >
+      <UBadge :color="meta.color" variant="subtle" size="md" :class="collapsed ? 'px-1.5' : 'w-full justify-start'">
+        <UIcon :name="meta.icon" class="size-3.5 shrink-0" :class="meta.spin ? 'animate-spin' : ''" />
+        <span v-if="!collapsed">{{ meta.label }}</span>
+      </UBadge>
+    </NuxtLink>
+  </UTooltip>
+</template>
+```
+
+- [ ] **Step 4: Verify in the app**
+
+Run: `bun run ui:dev`. Click Settings in the sidebar.
+Expected: three sections in one narrow column, Settings sits below a divider under Downloads, the sidebar footer no longer shows the colourway buttons, and the status chip navigates to `/settings`. Check the page in both light and dark.
+
+- [ ] **Step 5: Typecheck, lint and commit**
+
+```bash
+bun run typecheck && bun run lint
+git add app/pages/settings.vue app/layouts/default.vue app/components/CameraStatusChip.vue
+git commit -m "feat: add a dedicated settings page"
+```
+
+---
+
+### Task 6: Reduce the home page to connect and disconnect
+
+**Files:**
+- Modify: `app/pages/index.vue`
+
+**Interfaces:**
+- Consumes: `useCamera()`, `LunaModel` (existing), the `/settings` route from Task 5.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Replace the page**
+
+Replace the entire contents of `app/pages/index.vue`:
+
+```vue
+<script setup lang="ts">
+const { info, error, isConnected, isBusy, available, connect, disconnect } = useCamera();
+
+useHead({ title: "Connect" });
+
+const celebrate = ref(0);
+watch(isConnected, (connected) => {
+  if (connected) celebrate.value += 1;
+});
+</script>
+
+<template>
+  <UDashboardPanel id="connect">
+    <template #header>
+      <UDashboardNavbar title="Connect">
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <div class="grid h-full grid-cols-1 gap-8 lg:grid-cols-2 lg:items-center">
+        <div class="order-2 flex flex-col justify-center gap-6 lg:order-1 lg:pl-6">
+          <template v-if="isConnected && info">
+            <div class="space-y-1.5">
+              <h1 class="text-3xl font-semibold tracking-tight text-highlighted">
+                {{ info.deviceName ?? "Luna Ultra" }}
+              </h1>
+              <p class="font-mono text-sm text-muted">{{ info.ssid ?? info.host }}</p>
+            </div>
+
+            <div class="flex max-w-md items-center gap-3">
+              <UButton size="xl" icon="i-lucide-images" label="Open gallery" to="/gallery" />
+              <UButton
+                class="ml-auto"
+                size="xl"
+                label="Disconnect"
+                icon="i-lucide-unplug"
+                color="neutral"
+                variant="ghost"
+                @click="disconnect"
+              />
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="space-y-3">
+              <h1 class="text-3xl font-semibold tracking-tight text-highlighted lg:text-4xl">
+                Pair your Luna Ultra
+              </h1>
+              <p class="max-w-md text-muted">
+                Join the camera's Wi-Fi network, then connect to browse, download and manage everything you shot.
+              </p>
+            </div>
+
+            <UAlert
+              v-if="!available"
+              class="max-w-md"
+              icon="i-lucide-monitor-down"
+              color="warning"
+              variant="subtle"
+              title="Desktop app required"
+              description="Connecting to the camera needs the packaged Luna Ultra desktop app."
+            />
+
+            <UAlert
+              v-if="error"
+              class="max-w-md"
+              icon="i-lucide-triangle-alert"
+              color="error"
+              variant="subtle"
+              :title="error"
+            >
+              <template #actions>
+                <UButton label="Open settings" size="xs" color="neutral" variant="outline" to="/settings" />
+              </template>
+            </UAlert>
+
+            <div class="flex max-w-md items-center gap-3">
+              <UButton
+                size="xl"
+                icon="i-lucide-cable"
+                :label="isBusy ? 'Connecting' : 'Connect camera'"
+                :loading="isBusy"
+                :disabled="!available"
+                @click="connect"
+              />
+              <UButton size="xl" label="View downloads" color="neutral" variant="ghost" to="/downloads" />
+            </div>
+          </template>
+        </div>
+
+        <div class="order-1 h-72 min-h-0 lg:order-2 lg:h-full">
+          <LunaModel class="size-full" :celebrate="celebrate" />
+        </div>
+      </div>
+    </template>
+  </UDashboardPanel>
+</template>
+```
+
+- [ ] **Step 2: Verify in the app**
+
+Run: `bun run ui:dev`.
+Expected: no address field on the home page, no device table, one primary button per state, no Disconnect in the navbar. Connecting against the mock server still works using the persisted host from Task 3, and a failed connect shows the alert with an "Open settings" action.
+
+- [ ] **Step 3: Typecheck, lint and commit**
+
+```bash
+bun run typecheck && bun run lint
+git add app/pages/index.vue
+git commit -m "feat: reduce the home page to connect and disconnect"
+```
+
+---
+
+### Task 7: Media preview action row and arrow insets
+
+**Files:**
+- Modify: `app/components/MediaPreview.vue:84-88` (header actions)
+- Modify: `app/components/MediaPreview.vue:143-166` (prev/next arrows)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing consumed by later tasks. The `download`, `delete` and `open` emits are unchanged.
+
+- [ ] **Step 1: Rebuild the header action row**
+
+In `app/components/MediaPreview.vue`, add a dropdown items computed to the `<script setup>` block, after the existing `takenLabel` definition:
+
+```ts
+const moreItems = computed(() => [
+  [
+    {
+      label: "Delete from camera",
+      icon: "i-lucide-trash-2",
+      color: "error" as const,
+      onSelect: () => emit("delete"),
+    },
+  ],
+]);
+```
+
+Replace the header action row (the `<div class="flex items-center gap-1.5">` holding the three buttons):
+
+```vue
+          <div class="flex items-center gap-1.5">
+            <UButton icon="i-lucide-arrow-down-to-line" label="Download" size="sm" color="neutral" variant="outline" @click="emit('download')" />
+            <UDropdownMenu :items="moreItems">
+              <UButton icon="i-lucide-ellipsis" size="sm" color="neutral" variant="ghost" aria-label="More actions" />
+            </UDropdownMenu>
+            <span class="mx-1 h-5 w-px bg-default" aria-hidden="true" />
+            <UButton icon="i-lucide-x" size="sm" color="neutral" variant="ghost" aria-label="Close preview" @click="open = false" />
+          </div>
+```
+
+Delete is no longer a single click sitting next to Download. It takes opening the menu first, which is the point: it erases from the camera and cannot be undone.
+
+- [ ] **Step 2: Inset the prev/next arrows**
+
+The image area is the `<div class="relative flex min-h-0 flex-1 items-center justify-center bg-black/95 dark:bg-black">`. Give it horizontal padding so a wide image cannot run under the arrows, and pull the arrows into that padding.
+
+Change that div's class to:
+
+```
+relative flex min-h-0 flex-1 items-center justify-center bg-black/95 px-16 dark:bg-black
+```
+
+Then change the two arrow buttons' positioning classes from `left-4` and `right-4` to `left-3` and `right-3`:
+
+```vue
+          <UButton
+            v-if="hasPrev"
+            icon="i-lucide-chevron-left"
+            size="lg"
+            color="neutral"
+            variant="solid"
+            class="absolute left-3 top-1/2 -translate-y-1/2"
+            aria-label="Previous file"
+            @click="emit('prev')"
+          />
+          <UButton
+            v-if="hasNext"
+            icon="i-lucide-chevron-right"
+            size="lg"
+            color="neutral"
+            variant="solid"
+            class="absolute right-3 top-1/2 -translate-y-1/2"
+            aria-label="Next file"
+            @click="emit('next')"
+          />
+```
+
+`PanoViewer` and the loading overlay use `absolute inset-0`, so they still fill the area edge to edge; only the `object-contain` image is inset, which is what we want.
+
+- [ ] **Step 3: Verify in the app**
+
+Run: `bun run ui:dev`, open a photo in the gallery preview.
+Expected: Download is a labelled outline button, Delete lives behind the ellipsis menu, Close sits after a hairline separator. A wide photo no longer runs underneath the arrows. The image stays centred (the fix from the earlier commit still holds).
+
+- [ ] **Step 4: Typecheck, lint and commit**
+
+```bash
+bun run typecheck && bun run lint
+git add app/components/MediaPreview.vue
+git commit -m "fix: separate delete from download in the media preview"
+```
+
+---
+
+### Task 8: Gallery day selection and skeleton loading
+
+**Files:**
+- Modify: `app/pages/gallery.vue:216-226` (the day heading row)
+- Modify: `app/pages/gallery.vue:215-219` (the loading state block)
+
+**Interfaces:**
+- Consumes: `tileMin` (existing computed), `loadingLibrary` (existing).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Stop hiding "Select day" behind hover**
+
+In `app/pages/gallery.vue`, replace the day heading row:
+
+```vue
+          <div class="mb-2.5 flex items-baseline gap-3">
+            <h2 class="text-sm font-semibold text-highlighted">{{ group.label }}</h2>
+            <span class="font-mono text-xs text-muted tabular-nums">{{ group.items.length }}</span>
+            <UButton
+              :label="group.items.every((i) => selected.has(i.id)) ? 'Deselect day' : 'Select day'"
+              size="xs"
+              color="neutral"
+              variant="ghost"
+              @click="selectGroup(group.items.map((i) => i.id))"
+            />
+          </div>
+```
+
+The `group/day` class and the `opacity-0` / `group-hover/day:opacity-100` pair are gone. A control that performs a real action should not be invisible until the pointer happens to land on it, and it was unreachable by pointerless navigation.
+
+- [ ] **Step 2: Replace the loading spinner with grid skeletons**
+
+Replace the loading branch (the `v-else-if="loadingLibrary && groups.length === 0"` block):
+
+```vue
+      <div v-else-if="loadingLibrary && groups.length === 0" class="space-y-8" aria-busy="true">
+        <section v-for="section in 2" :key="section">
+          <div class="mb-2.5 h-5 w-32 animate-pulse rounded bg-elevated" />
+          <div
+            class="grid gap-2"
+            :style="{ gridTemplateColumns: `repeat(auto-fill, minmax(${tileMin}px, 1fr))` }"
+          >
+            <div v-for="tile in 12" :key="tile" class="aspect-square animate-pulse rounded-lg bg-elevated" />
+          </div>
+        </section>
+      </div>
+```
+
+Same grid template as the real content, so nothing shifts when the library lands.
+
+- [ ] **Step 3: Verify in the app**
+
+Run: `bun run ui:dev`, connect against the mock server and watch the gallery load.
+Expected: skeleton tiles in the real grid shape rather than a centred spinner, no layout jump when the library arrives, and "Select day" visible on every day heading without hovering.
+
+- [ ] **Step 4: Typecheck, lint and commit**
+
+```bash
+bun run typecheck && bun run lint
+git add app/pages/gallery.vue
+git commit -m "fix: reveal day selection and use grid skeletons while loading"
+```
+
+---
+
+### Task 9: Full verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run everything**
+
+```bash
+bun run vitest run && bun run typecheck && bun run lint
+```
+
+Expected: all suites pass, no type errors, no lint errors.
+
+- [ ] **Step 2: Manual pass against the mock server**
+
+Start `luna_mock_server`, run `bun run ui:dev`, then walk through:
+
+1. Connect from the home page with no prior configuration. It uses the default host.
+2. Change the host in Settings to the mock address, reload the app, confirm the value survived.
+3. Browse the gallery, open a preview, confirm centring, the action row and the arrow insets.
+4. Kill the mock server, keep scrolling the gallery so thumbnails fail. After three failed requests the session drops with "Lost contact with the camera. Disconnected after 3 failed requests." and does not silently reconnect.
+5. Restart the mock server, reconnect from the home page, confirm the session recovers.
+6. Repeat steps 3 and 4 in the other colour mode.
+
+- [ ] **Step 3: Report honestly**
+
+Any step that could not be verified is stated as unverified in the summary, not implied to have passed.

--- a/docs/superpowers/specs/2026-07-22-settings-page-and-auto-disconnect-design.md
+++ b/docs/superpowers/specs/2026-07-22-settings-page-and-auto-disconnect-design.md
@@ -1,0 +1,256 @@
+# Settings page, auto-disconnect, and UI pass
+
+Date: 2026-07-22
+Status: approved, ready for planning
+
+## Problem
+
+Three things, one release:
+
+1. The home page doubles as a configuration form. The IP address input, the
+   macOS Local Network troubleshooting list and the device detail table all sit
+   on the first screen the user sees. Home should be a connect/disconnect
+   surface and nothing else.
+2. When the camera stops responding mid-session (Wi-Fi drops, camera sleeps,
+   battery dies) the app keeps showing a connected session that no longer works.
+   Requests hang or fail one by one with no session-level reaction.
+3. The layout and visual detailing across the app have drifted. With a new page
+   being added, this is the moment to do a targeted consistency pass.
+
+## Scope
+
+In scope: a new `/settings` route, a reduced home page, a camera-health
+detector that force-disconnects, and a targeted visual pass over the existing
+five surfaces.
+
+Out of scope: any change to the Rust/Tauri command layer, the media indexing
+logic, the RAW decode path, or the watermark rendering pipeline. No new
+dependencies.
+
+---
+
+## 1. Settings page
+
+New route `app/pages/settings.vue`, rendered in a `UDashboardPanel` like the
+other pages. Reached from a new sidebar nav entry (`i-lucide-settings`) pinned
+at the bottom of the nav list, and from the camera status chip in the sidebar
+footer, which becomes a link to this page.
+
+Three sections, in this order.
+
+### Camera
+
+- Host `UInput`, label above the field, persistent helper text below it
+  ("Default Luna Ultra Wi-Fi gateway. Include a port for the dev mock:
+  127.0.0.1:18080"). Not a placeholder-as-label.
+- The value persists to `localStorage` under `luna-camera-host`, restored on
+  boot. Today the host resets to the default on every launch, which is why
+  users with a non-default gateway have to retype it every session. Persistence
+  is what lets the home page ship a bare Connect button.
+- Connect / Disconnect action for this section. Disconnect is styled as the
+  destructive-adjacent action and is visually separated from the field group.
+- The troubleshooting list (join the camera Wi-Fi, confirm the gateway, allow
+  Local Network on macOS) moves here, shown inline under the field rather than
+  only on error.
+- When connected, the read-only device table renders here: device name,
+  address, serial, firmware, file count. Values use tabular figures so they do
+  not jitter as the library count changes.
+
+### Watermark
+
+The body of `DownloadOptionsModal` (the enable switch, the live
+`WatermarkCanvas` preview and the position picker) is extracted into
+`app/components/WatermarkSettingsForm.vue` and consumed by both the modal and
+this page. The modal keeps its own title, footer and download button; only the
+form body is shared. A "Reset to default" action is added here, wired to
+`useWatermarkSettings().reset`, which already exists and is currently unused.
+
+### Appearance
+
+`ColorwayToggle` moves out of the sidebar footer into this section, with a
+label and a one-line description. The sidebar footer is left with the update
+banner and the camera status chip.
+
+---
+
+## 2. Home page reduced to connect / disconnect
+
+`app/pages/index.vue` keeps the `LunaModel` visual and the headline and drops
+the host form and the device table.
+
+- **Disconnected**: headline, one line of subtext, a single primary
+  "Connect camera" button that uses the persisted host, and a quiet secondary
+  link to Downloads.
+- **Connecting**: the same button in loading state, label "Connecting".
+- **Connected**: the device name, the SSID or address as a single quiet line,
+  a primary "Open gallery" button and a secondary "Disconnect".
+- **Error**: a `UAlert` with the failure message and an "Open settings" link.
+  No inline form on this page.
+
+There is exactly one primary action per state. The `Disconnect` button
+currently duplicated in the page navbar is removed, since the body now owns it.
+
+---
+
+## 3. Auto-disconnect on repeated camera failures
+
+### The detector
+
+New module `app/utils/cameraHealth.ts`, framework-free so it unit-tests without
+Tauri or a Vue app instance:
+
+```ts
+export const FAILURE_THRESHOLD = 3;
+
+export function armCameraHealth(onDead: () => void): void;
+export function disarmCameraHealth(): void;
+export function reportCameraSuccess(): void;
+export function reportCameraFailure(): void;
+```
+
+Module-level state: the consecutive-failure count and the currently armed
+callback. `armCameraHealth` resets the count to zero and stores the callback,
+replacing any previous one. `disarmCameraHealth` clears both.
+
+### What counts as a failure
+
+Only **transport failures**: a thrown fetch. Connection refused, DNS failure,
+socket timeout, Wi-Fi disappearing.
+
+Any completed HTTP response resets the counter to zero, including a 404 or a
+500. A camera that answers is a camera that is alive, so a genuinely missing
+file must never kill the session. This is the single most important rule in the
+detector and the reason the counter lives in the fetch layer rather than in the
+image components.
+
+### Where it hooks in
+
+Inside `cameraFetch()` in `app/utils/lunaClient.ts`, the one function every
+camera request already passes through: the library listing, grid thumbnails,
+full-screen previews and RAW downloads. Wrapping it there means every request
+type feeds the same counter, and no call site has to remember to report.
+
+`reportCameraSuccess` / `reportCameraFailure` are no-ops while disarmed, so
+requests made before a session exists cannot trip it.
+
+### What happens on the third failure
+
+The callback fires exactly once, then the detector disarms itself so a burst of
+concurrent in-flight failures cannot fire it repeatedly.
+
+`useCamera` arms the detector on a successful `connect()` and disarms it in
+`disconnect()`. The callback runs a hard disconnect:
+
+- `wantConnection = false`
+- cancel the pending reconnect timer
+- `await lunaClient.disconnect()`
+- clear `info` and `library`
+- set `error` to "Lost contact with the camera. Disconnected after 3 failed
+  requests."
+
+Setting `wantConnection = false` is what keeps the existing backoff reconnect
+loop dormant, so the auto-reconnect machinery cannot immediately undo the
+disconnect. The user reconnects deliberately, from home or from Settings.
+
+The existing `luna://disconnected` Tauri event path is unchanged; it still
+schedules a reconnect. The two mechanisms cover different failures: the event
+means the control socket closed, the detector means the HTTP surface stopped
+answering while the socket still looks open.
+
+---
+
+## 4. Visual and UX pass
+
+**Design read**: a desktop product utility for prosumer photographers, in
+redesign-preserve mode, with a calm hardware-companion language, leaning on the
+existing Nuxt UI v4 token system rather than a new visual identity.
+
+Dials: `DESIGN_VARIANCE 4`, `MOTION_INTENSITY 3`, `VISUAL_DENSITY 6`. Product UI
+wants predictability over asymmetry, and the gallery is legitimately dense.
+
+The generated design-system recommendation (Orbitron display type, `#7C3AED`
+violet, "Exaggerated Minimalism") is rejected. It is a landing-page recipe, and
+the violet is exactly the AI-default accent the anti-slop rules ban. The app
+keeps its existing Nuxt UI semantic tokens.
+
+This is levers 1 to 4 of the redesign protocol (typography, spacing, color,
+motion) plus one recomposition (the home page, covered in section 2). No
+information architecture changes beyond adding `/settings`. No route renames.
+
+### Global
+
+- **One radius scale.** Audit every rounded utility across the components and
+  collapse to the Nuxt UI default scale. No `rounded-[2px]` marker inside a
+  `rounded-lg` container.
+- **One accent.** Semantic tokens only (`text-muted`, `text-highlighted`,
+  `bg-elevated`). No raw hex, no second accent introduced by the new page.
+- **Tabular figures** on every number that updates in place: download
+  percentages, byte counts, file counts, the RAW download progress line.
+- **Focus-visible rings** on every interactive element, including the
+  hand-rolled watermark position buttons, which are currently `<button>`
+  elements with no focus style.
+- **`prefers-reduced-motion`** honored by the `LunaModel` celebrate animation
+  and the loader spinners. Under reduced motion the celebrate is skipped and
+  spinners become a static indicator.
+- **Contrast checked in both themes.** Light and dark are opened side by side
+  before the work is called done, not inferred from one.
+
+### Per surface
+
+- **Sidebar**: nav renders on one line at the narrowest collapsed and expanded
+  widths. Settings pinned at the bottom, visually separated from the three
+  primary destinations. The status chip becomes a link to `/settings`.
+- **Home**: covered in section 2. One primary CTA per state, CTA labels short
+  enough not to wrap.
+- **Gallery**: loading state becomes tile-shaped skeletons matching the grid
+  cell aspect, replacing bare spinners. An empty state that says the library is
+  empty and offers a refresh, rather than an empty grid.
+- **Downloads**: empty state and a failed-download row with an explicit retry
+  action.
+- **Settings**: labels above inputs, helper text present in markup, errors
+  below the related field, destructive action separated from the field group.
+
+### Copy audit
+
+Every visible string across the changed surfaces is re-read before shipping.
+No em-dashes anywhere in user-visible text. No invented precision. No
+performative-craftsman section labels.
+
+---
+
+## Testing
+
+Test-first, per project convention.
+
+`tests/cameraHealth.test.ts`:
+
+- three consecutive failures invoke the callback exactly once
+- a success between failures resets the counter, so failure/success/failure/
+  failure does not fire
+- failures while disarmed are ignored, and arming afterwards starts from zero
+- a fourth and fifth failure after the callback has fired do not invoke it
+  again
+- `armCameraHealth` called twice replaces the callback rather than stacking
+
+The existing suites (`cameraQueue`, `lunaIndex`, `media`, `watermark`, and the
+rest) must stay green; `cameraFetch` gains a wrapper and its behavior on the
+success path must not change.
+
+Manual verification, since the detector's real trigger cannot be unit-tested:
+connect to the camera or the mock server, kill the server, browse the gallery,
+and confirm the session drops to disconnected with the failure message after
+three failed requests, and that it does not silently reconnect.
+
+## Risks
+
+- **False positives.** A camera under heavy load could time out three times in
+  a row while still being reachable. Mitigated by counting only transport
+  failures, and by the fact that a single completed response resets the count.
+  If this proves too eager in practice, the threshold is one constant.
+- **Shared state across the app.** `cameraHealth` holds module-level state,
+  matching the existing pattern in `useCamera` (`retryTimer`,
+  `networkWatcherInstalled`). Tests must reset it between cases, so the module
+  exposes `disarmCameraHealth` for that purpose.
+- **Scope creep in the visual pass.** The pass is bounded to the levers listed
+  above. Anything that would require restructuring the gallery virtualization
+  or the download queue is out of scope for this change.

--- a/docs/superpowers/specs/2026-07-22-settings-page-and-auto-disconnect-design.md
+++ b/docs/superpowers/specs/2026-07-22-settings-page-and-auto-disconnect-design.md
@@ -159,62 +159,84 @@ answering while the socket still looks open.
 
 ---
 
-## 4. Visual and UX pass
+## 4. Layout and button placement
 
-**Design read**: a desktop product utility for prosumer photographers, in
-redesign-preserve mode, with a calm hardware-companion language, leaning on the
-existing Nuxt UI v4 token system rather than a new visual identity.
+No new visual identity, no font change, no palette change. The app keeps its
+Nuxt UI semantic tokens. This section is about where things sit on screen and
+which button goes where.
 
-Dials: `DESIGN_VARIANCE 4`, `MOTION_INTENSITY 3`, `VISUAL_DENSITY 6`. Product UI
-wants predictability over asymmetry, and the gallery is legitimately dense.
+### Rule applied everywhere
 
-The generated design-system recommendation (Orbitron display type, `#7C3AED`
-violet, "Exaggerated Minimalism") is rejected. It is a landing-page recipe, and
-the violet is exactly the AI-default accent the anti-slop rules ban. The app
-keeps its existing Nuxt UI semantic tokens.
+**One action row per surface, and destructive actions never sit flush against
+the action you actually want.** Right now Download and Delete are adjacent
+ghost buttons in the preview header, which is a mis-click waiting to happen on
+files that cannot be recovered.
 
-This is levers 1 to 4 of the redesign protocol (typography, spacing, color,
-motion) plus one recomposition (the home page, covered in section 2). No
-information architecture changes beyond adding `/settings`. No route renames.
+### Home
 
-### Global
+Currently the actions are split across two places: a Disconnect in the page
+navbar and Connect / View downloads inside the body form.
 
-- **One radius scale.** Audit every rounded utility across the components and
-  collapse to the Nuxt UI default scale. No `rounded-[2px]` marker inside a
-  `rounded-lg` container.
-- **One accent.** Semantic tokens only (`text-muted`, `text-highlighted`,
-  `bg-elevated`). No raw hex, no second accent introduced by the new page.
-- **Tabular figures** on every number that updates in place: download
-  percentages, byte counts, file counts, the RAW download progress line.
-- **Focus-visible rings** on every interactive element, including the
-  hand-rolled watermark position buttons, which are currently `<button>`
-  elements with no focus style.
-- **`prefers-reduced-motion`** honored by the `LunaModel` celebrate animation
-  and the loader spinners. Under reduced motion the celebrate is skipped and
-  spinners become a static indicator.
-- **Contrast checked in both themes.** Light and dark are opened side by side
-  before the work is called done, not inferred from one.
+- Remove the navbar Disconnect. The navbar keeps only the title and the sidebar
+  collapse toggle.
+- One action row in the body, left-aligned under the copy, primary first:
+  - disconnected: `Connect camera` (primary), `View downloads` (ghost)
+  - connected: `Open gallery` (primary), `Disconnect` (ghost, pushed to the
+    right of the row with a gap so it is not adjacent to the primary)
+- The 3D model column keeps its half of the split at `lg` and drops below the
+  copy on narrower windows, as it does now.
 
-### Per surface
+### Media preview
 
-- **Sidebar**: nav renders on one line at the narrowest collapsed and expanded
-  widths. Settings pinned at the bottom, visually separated from the three
-  primary destinations. The status chip becomes a link to `/settings`.
-- **Home**: covered in section 2. One primary CTA per state, CTA labels short
-  enough not to wrap.
-- **Gallery**: loading state becomes tile-shaped skeletons matching the grid
-  cell aspect, replacing bare spinners. An empty state that says the library is
-  empty and offers a refresh, rather than an empty grid.
-- **Downloads**: empty state and a failed-download row with an explicit retry
-  action.
-- **Settings**: labels above inputs, helper text present in markup, errors
-  below the related field, destructive action separated from the field group.
+Currently the header is `Download | Delete | Close` as three adjacent buttons
+in the top-right, and the prev/next arrows float over the image edges.
 
-### Copy audit
+- Header right becomes `Download` (outline, labeled), then a separator gap,
+  then `Close`. Delete moves out of the row into an overflow menu
+  (`i-lucide-ellipsis`) placed between them, so the destructive action takes
+  two deliberate clicks.
+- Filename and timestamp stay left-aligned in the header.
+- Prev/next arrows stay vertically centered but move inside the image area's
+  padding so they no longer overlap the image edge at wide aspect ratios.
 
-Every visible string across the changed surfaces is re-read before shipping.
-No em-dashes anywhere in user-visible text. No invented precision. No
-performative-craftsman section labels.
+### Gallery
+
+- **"Select day" is currently invisible until hover** (`opacity-0` until
+  `group-hover/day`). A hidden control that performs a real action should not
+  be hover-gated. It becomes always visible but quiet (ghost, small), sitting
+  to the right of the day heading and count.
+- Toolbar keeps filters on the left and the thumbnail-size group on the right,
+  which is the right split. The size buttons stay icon-only but keep their
+  existing `aria-label`s.
+- The loading state becomes tile-shaped skeleton cells in the actual grid
+  rather than a centered spinner, so the layout does not jump when the library
+  lands.
+- The floating `SelectionBar` keeps its `pb-24` scroll reserve so it never
+  covers the last row.
+
+### Downloads
+
+- Empty state gets the same centered icon plus copy plus action treatment the
+  gallery already uses, with a `Go to gallery` action.
+- A failed row gets an inline `Retry` button on the row itself, not in a global
+  toolbar.
+
+### Settings
+
+- Single column, `max-w-2xl`, sections separated by a heading plus a divider.
+  Not a two-column form; the fields are too few to justify it.
+- Labels above inputs, helper text below, full width within the column.
+- Each section's action sits at the section's bottom-right.
+- Camera section: the field group first, then a divider, then
+  Connect / Disconnect. Disconnect is visually separated from the input so it
+  is never the thing you hit while tabbing out of the host field.
+
+### Sidebar
+
+- Settings joins the nav list at the bottom, separated from the three primary
+  destinations by a spacer so it reads as secondary.
+- The camera status chip in the footer becomes a link to `/settings`, since it
+  is the thing users click when the connection looks wrong.
 
 ---
 

--- a/tests/cameraHealth.test.ts
+++ b/tests/cameraHealth.test.ts
@@ -7,58 +7,149 @@ import {
   reportCameraSuccess,
 } from "~/utils/cameraHealth";
 
+/** Let the in-flight probe promise chain settle. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** A probe that reports the camera as gone, so failures reach `onDead`. */
+const deadProbe = () => Promise.resolve(false);
+
 describe("cameraHealth", () => {
   beforeEach(() => {
     disarmCameraHealth();
   });
 
-  it("fires once after three consecutive failures", () => {
+  it("fires once after three consecutive failures", async () => {
     const onDead = vi.fn();
-    armCameraHealth(onDead);
+    armCameraHealth(onDead, deadProbe);
     for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
     expect(onDead).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fire before the threshold", () => {
+  it("does not fire before the threshold", async () => {
     const onDead = vi.fn();
-    armCameraHealth(onDead);
+    armCameraHealth(onDead, deadProbe);
     for (let i = 0; i < FAILURE_THRESHOLD - 1; i++) reportCameraFailure();
+    await flush();
     expect(onDead).not.toHaveBeenCalled();
   });
 
-  it("resets the count on any success", () => {
+  it("resets the count on any success", async () => {
     const onDead = vi.fn();
-    armCameraHealth(onDead);
+    armCameraHealth(onDead, deadProbe);
     reportCameraFailure();
     reportCameraSuccess();
     reportCameraFailure();
     reportCameraFailure();
+    await flush();
     expect(onDead).not.toHaveBeenCalled();
   });
 
-  it("ignores failures while disarmed", () => {
+  it("ignores failures while disarmed", async () => {
     const onDead = vi.fn();
     for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
-    armCameraHealth(onDead);
+    armCameraHealth(onDead, deadProbe);
     reportCameraFailure();
+    await flush();
     expect(onDead).not.toHaveBeenCalled();
   });
 
-  it("does not fire again after it has fired", () => {
+  it("does not fire again after it has fired", async () => {
     const onDead = vi.fn();
-    armCameraHealth(onDead);
+    armCameraHealth(onDead, deadProbe);
     for (let i = 0; i < FAILURE_THRESHOLD + 3; i++) reportCameraFailure();
+    await flush();
+    for (let i = 0; i < FAILURE_THRESHOLD + 3; i++) reportCameraFailure();
+    await flush();
     expect(onDead).toHaveBeenCalledTimes(1);
   });
 
-  it("replaces the callback when armed twice", () => {
+  it("replaces the callback when armed twice", async () => {
     const first = vi.fn();
     const second = vi.fn();
-    armCameraHealth(first);
+    armCameraHealth(first, deadProbe);
     reportCameraFailure();
-    armCameraHealth(second);
+    armCameraHealth(second, deadProbe);
     for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not disconnect when the probe says the camera is alive", async () => {
+    const onDead = vi.fn();
+    const probe = vi.fn(() => Promise.resolve(true));
+    armCameraHealth(onDead, probe);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("resets the count after a successful probe", async () => {
+    const onDead = vi.fn();
+    const probe = vi.fn(() => Promise.resolve(true));
+    armCameraHealth(onDead, probe);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
+    // The counter is back at zero, so it takes a whole fresh run to probe again.
+    for (let i = 0; i < FAILURE_THRESHOLD - 1; i++) reportCameraFailure();
+    await flush();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("fires exactly once when the probe also fails", async () => {
+    const onDead = vi.fn();
+    const probe = vi.fn(() => Promise.resolve(false));
+    armCameraHealth(onDead, probe);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a throwing probe as a dead camera", async () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead, () => Promise.reject(new Error("no route to host")));
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    await flush();
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a second probe while one is in flight", async () => {
+    const onDead = vi.fn();
+    let release: (alive: boolean) => void = () => {};
+    const probe = vi.fn(() => new Promise<boolean>((resolve) => {
+      release = resolve;
+    }));
+    armCameraHealth(onDead, probe);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    // A burst of further failures arrives while the probe is still open.
+    for (let i = 0; i < FAILURE_THRESHOLD * 2; i++) reportCameraFailure();
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    release(true);
+    await flush();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when disarmed while the probe is in flight", async () => {
+    const onDead = vi.fn();
+    let release: (alive: boolean) => void = () => {};
+    const probe = vi.fn(() => new Promise<boolean>((resolve) => {
+      release = resolve;
+    }));
+    armCameraHealth(onDead, probe);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    disarmCameraHealth();
+    release(false);
+    await flush();
+    expect(onDead).not.toHaveBeenCalled();
   });
 });

--- a/tests/cameraHealth.test.ts
+++ b/tests/cameraHealth.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FAILURE_THRESHOLD,
+  armCameraHealth,
+  disarmCameraHealth,
+  reportCameraFailure,
+  reportCameraSuccess,
+} from "~/utils/cameraHealth";
+
+describe("cameraHealth", () => {
+  beforeEach(() => {
+    disarmCameraHealth();
+  });
+
+  it("fires once after three consecutive failures", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire before the threshold", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD - 1; i++) reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("resets the count on any success", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    reportCameraFailure();
+    reportCameraSuccess();
+    reportCameraFailure();
+    reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("ignores failures while disarmed", () => {
+    const onDead = vi.fn();
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    armCameraHealth(onDead);
+    reportCameraFailure();
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("does not fire again after it has fired", () => {
+    const onDead = vi.fn();
+    armCameraHealth(onDead);
+    for (let i = 0; i < FAILURE_THRESHOLD + 3; i++) reportCameraFailure();
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the callback when armed twice", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    armCameraHealth(first);
+    reportCameraFailure();
+    armCameraHealth(second);
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) reportCameraFailure();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Four things, one branch.

**1. Dedicated settings page.** `/settings` now holds the camera address, device details (serial, firmware, file count), watermark defaults and the colourway toggle. The camera host persists to `localStorage`, which is what lets the home page ship a bare Connect button. Watermark controls were extracted into a shared `WatermarkSettingsForm.vue` used by both the settings page and the download modal.

**2. Home page reduced to connect/disconnect.** No IP field, no device table, no duplicate Disconnect in the navbar. One primary action per state; errors link to Settings.

**3. Auto-disconnect when the camera goes silent.** New `app/utils/cameraHealth.ts` counts consecutive transport failures, fed from the single `cameraFetch` chokepoint so every request type feeds it. Only a thrown request counts; any completed HTTP response, including a 404 for a missing file, proves the camera is alive and resets the counter. Reaching the threshold triggers a cheap probe to the storage root, and the session is dropped only if that probe also fails, so a large RAW download that retries and drops cannot kill a healthy session. On a confirmed drop the session is torn down with `wantConnection` cleared, keeping the backoff reconnect loop dormant.

**4. Layout and button placement.** Delete moved out of the media preview header row into an overflow menu so it no longer sits one click from Download; prev/next arrows inset so wide images stop running underneath them; gallery "Select day" no longer invisible until hover; gallery loading uses grid-shaped skeletons instead of a centred spinner, so nothing shifts when the library lands. Also centres preview images that previously hugged the left edge.

Spec and plan are committed under `docs/superpowers/`.

## Test plan

- [x] `bun run vitest run` - 87/87 pass (6 new `cameraHealth` tests covering threshold, reset-on-success, disarmed no-op, fire-once, re-arm, and the probe paths)
- [x] `bun run typecheck`, `bun run lint`, `bun run generate` all clean
- [x] Browser-verified: home page has zero inputs and only Connect camera + View downloads; `/settings` renders Camera, Watermark and Appearance sections; Settings appears in the nav; the sidebar chip links to `/settings` and announces live state
- [ ] Against a real or mock camera: connect, browse, then kill the camera and confirm the session drops with the probe verdict and does not silently reconnect
- [ ] Media preview overflow menu, arrow insets and loading skeletons at runtime
- [ ] Dark mode pass on the new settings page

The unchecked items need a live camera or a running app window and have not been verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)