### PR TITLE
fix(downloads): record the transferred byte count so sizes aren't 0 B

### DIFF
--- a/app/composables/useDownloads.ts
+++ b/app/composables/useDownloads.ts
@@ -5,6 +5,7 @@ import { getCameraTransport } from "~/utils/transport";
 
 export function useDownloads() {
   const queue = useState<DownloadEntry[]>("download-queue", () => []);
+  const { library } = useCamera();
   const { settings } = useWatermarkSettings();
   const toast = useToast();
   const running = useState<boolean>("download-running", () => false);
@@ -32,6 +33,9 @@ export function useDownloads() {
         if (!response.ok) throw new Error(`Camera transfer failed (${response.status})`);
         patch(entry.id, { progress: 45 });
         let blob = await response.blob();
+        // Measured before the watermark pass: this is the file's size on the
+        // camera, not the size of what we are about to write to disk.
+        recordSize(entry.item, blob.size);
         patch(entry.id, { progress: 70 });
         if (entry.watermarked && entry.item.type === "photo") {
           blob = await renderWatermarked(blob, settings.value);
@@ -46,6 +50,25 @@ export function useDownloads() {
         });
       }
     }
+  }
+
+  /**
+   * Record the transferred byte count. On firmware that disabled the HTTP
+   * autoindex the library comes from GET_FILE_LIST, which reports no size, so
+   * a downloaded file is the only place a real byte count ever appears — the
+   * Downloads row would otherwise read `0 B`. `blob.size` is exact and needs
+   * no `content-length` support, and it also beats the index listing's rounded
+   * "18M", so it wins over whatever the item carried.
+   *
+   * Written back to the shared library item as well as the queue entry: the
+   * gallery may hand over a copy, and the size belongs to the file rather than
+   * to this one transfer, so re-downloading isn't the only way to learn it.
+   */
+  function recordSize(item: MediaItem, size: number) {
+    if (size <= 0) return;
+    item.size = size;
+    const libraryItem = library.value.find((candidate) => candidate.id === item.id);
+    if (libraryItem && libraryItem !== item) libraryItem.size = size;
   }
 
   /**

--- a/app/types/media.ts
+++ b/app/types/media.ts
@@ -17,7 +17,11 @@ export interface MediaItem {
   panoramic: boolean;
   /** Unix epoch ms of capture time (filename timestamp, else index column) */
   takenAt: number;
-  /** File size in bytes, parsed from the camera's index listing */
+  /**
+   * File size in bytes, parsed from the camera's index listing. 0 when the
+   * listing came from GET_FILE_LIST, which reports no size; a download
+   * measures the real count and writes it back here.
+   */
   size: number;
   /** Pixel dimensions are unknown until the file is decoded */
   width?: number;

--- a/app/utils/lunaIndex.ts
+++ b/app/utils/lunaIndex.ts
@@ -184,7 +184,9 @@ export function buildMediaItems(
  * Build raw entries from GET_FILE_LIST paths. Firmware 1.0.238+ disabled the
  * HTTP directory autoindex, so files are enumerated over the control session
  * instead; each file stays fetchable by its URL while the session is held.
- * Size isn't reported here — it's resolved lazily when a file is downloaded.
+ * Size isn't reported by GET_FILE_LIST, so entries start at 0 and stay there
+ * until the file is downloaded: `useDownloads` measures the transferred blob
+ * and writes the byte count back onto the library item.
  */
 export function entriesFromPaths(paths: string[], urlFor: (path: string) => string): RawEntry[] {
   const entries: RawEntry[] = [];

--- a/tests/lunaIndex.test.ts
+++ b/tests/lunaIndex.test.ts
@@ -171,6 +171,10 @@ describe("GET_FILE_LIST path listing (firmware 1.0.238+)", () => {
     expect(dng.previewUrl).toBe("http://192.168.42.1/DCIM/Camera01/IMG_20260724_134210_135.jpg");
   });
 
+  it("leaves size at 0 for a download to measure and fill in", () => {
+    expect(items.every((i) => i.size === 0)).toBe(true);
+  });
+
   it("parses the capture time from the filename", () => {
     const vid = items.find((i) => i.ext === "mp4")!;
     expect(vid.takenAt).toBe(new Date(2026, 6, 24, 18, 20, 11).getTime());

--- a/tests/nuxt/useDownloads.test.ts
+++ b/tests/nuxt/useDownloads.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetCameraTransport, setCameraTransport } from "~/utils/transport";
+import { makeFakeTransport } from "../helpers/fakeTransport";
+import { makeMediaItem } from "../helpers/media";
+import { mountComposable } from "./harness";
+
+vi.mock("~/utils/saveFile", () => ({
+  isTauri: () => false,
+  saveBlob: vi.fn(async (_blob: Blob, fileName: string) => `Downloads/Luna Ultra/${fileName}`),
+}));
+
+const renderWatermarked = vi.fn(async (_blob: Blob, _settings: unknown) =>
+  bodyOf(WATERMARKED_BYTES),
+);
+vi.mock("~/utils/watermarkClient", () => ({
+  renderWatermarked: (blob: Blob, settings: unknown) => renderWatermarked(blob, settings),
+}));
+
+const CAMERA_BYTES = 4096;
+const WATERMARKED_BYTES = 9000;
+
+function bodyOf(bytes: number): Blob {
+  return new Blob([new Uint8Array(bytes)]);
+}
+
+function respondWith(bytes: number) {
+  // Uint8Array rather than a Blob body: this environment's Response
+  // stringifies a Blob instead of streaming it.
+  return makeFakeTransport({
+    fetch: vi.fn(async () => new Response(new Uint8Array(bytes), { status: 200 })),
+  });
+}
+
+/** Resolve once every queued transfer has left the queue's active states. */
+async function drain(active: { value: unknown[] }) {
+  for (let tick = 0; tick < 100 && active.value.length > 0; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("useDownloads", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    renderWatermarked.mockClear();
+  });
+
+  afterEach(() => {
+    resetCameraTransport();
+    clearNuxtState(
+      [
+        "download-queue",
+        "download-running",
+        "watermark-settings",
+        "camera-library",
+        "camera-host",
+        "camera-status",
+        "camera-info",
+        "camera-error",
+        "camera-library-loading",
+        "camera-want-connection",
+        "camera-retry-attempt",
+      ],
+      { reset: true },
+    );
+  });
+
+  it("records the transferred byte count on an entry the file list left at zero", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: false });
+    await drain(downloads.active);
+
+    const entry = downloads.queue.value[0]!;
+    expect(entry.status).toBe("done");
+    expect(entry.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("backfills the size onto the shared library item, not just the queue entry", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const { camera, downloads } = await mountComposable(() => ({
+      camera: useCamera(),
+      downloads: useDownloads(),
+    }));
+    camera.library.value = [makeMediaItem({ size: 0 })];
+    // The gallery can hand over a copy, so the entry and the library item are
+    // not guaranteed to be the same object.
+    downloads.enqueue([{ ...camera.library.value[0]! }], { watermark: false });
+    await drain(downloads.active);
+
+    expect(camera.library.value[0]!.size).toBe(CAMERA_BYTES);
+  });
+
+  it("records the camera file's size, not the watermarked output's", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: true });
+    await drain(downloads.active);
+
+    expect(renderWatermarked).toHaveBeenCalled();
+    expect(downloads.queue.value[0]!.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("replaces an index-estimated size with the exact byte count", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 18 * 1024 * 1024 })], { watermark: false });
+    await drain(downloads.active);
+
+    expect(downloads.queue.value[0]!.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("leaves the size untouched when the transfer fails", async () => {
+    setCameraTransport(
+      makeFakeTransport({
+        fetch: vi.fn(async () => new Response(null, { status: 404 })),
+      }),
+    );
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: false });
+    await drain(downloads.active);
+
+    const entry = downloads.queue.value[0]!;
+    expect(entry.status).toBe("error");
+    expect(entry.item.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #3.

## Problem

On firmware 1.0.238+ the HTTP autoindex is disabled, so the library is enumerated over the control session with `GET_FILE_LIST` — which reports no sizes. `entriesFromPaths` hard-coded `size: 0` with a comment promising the size would be "resolved lazily when a file is downloaded", but nothing ever wrote it back. The Downloads page then rendered `0 B` for completed transfers.

Since `item.size` is the only size the app has, this also left anything wanting a byte count — percentage progress, disk-space estimates, sorting by size — with nothing to work from.

## Fix

`recordSize(item, size)` in `useDownloads`, called with `blob.size` immediately after `await response.blob()` and deliberately **before** the watermark pass, so it records the camera file's size rather than the size of the re-encoded output being written to disk.

It writes to `entry.item.size` and also backfills the matching item in the shared `library` by id — resolving the open question in the issue toward persisting it. That's safe: `library` is a `useState` array of plain reactive `MediaItem`s whose only other mutations are whole-array replacements, and the write is guarded by `size <= 0` so a failed transfer can't zero out a good value.

`blob.size` is exact and needs no `content-length` support. It also beats the autoindex's rounded `18M`, so it wins over whatever the item already carried.

## Tests

New `tests/nuxt/useDownloads.test.ts`:
- records the transferred byte count on an entry the file list left at zero
- backfills the size onto the shared library item, not just the queue entry
- records the camera file's size, not the watermarked output's
- replaces an index-estimated size with the exact byte count
- leaves the size untouched when the transfer fails

Plus one in `tests/lunaIndex.test.ts`. Written first and confirmed red (4 failed / 1 passed) before implementing.

`bun run test`, `bun run lint` and `bun run typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)