### PR TITLE
fix(downloads): stop promising a watermark on RAW files

### DIFF
--- a/app/components/DownloadOptionsModal.vue
+++ b/app/components/DownloadOptionsModal.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
 import type { MediaItem } from "~/types/media";
+import { watermarkNote, watermarkScope } from "~/utils/watermark";
 
 const props = defineProps<{ items: MediaItem[] }>();
 
 const emit = defineEmits<{ close: [confirmed: boolean] }>();
 
-const photos = computed(() => props.items.filter((item) => item.type === "photo"));
-const videos = computed(() => props.items.filter((item) => item.type === "video"));
-const previewSrc = computed(() => photos.value[0]?.srcUrl);
+const scope = computed(() => watermarkScope(props.items));
+const note = computed(() => watermarkNote(scope.value));
+// Only a renderable photo can stand in for the watermark preview.
+const previewSrc = computed(() => scope.value.watermarkable[0]?.srcUrl);
 
 const summary = computed(() => {
+  const photos = scope.value.watermarkable.length + scope.value.raw.length;
+  const videos = scope.value.videos.length;
   const parts: string[] = [];
-  if (photos.value.length > 0)
-    parts.push(`${photos.value.length} ${photos.value.length === 1 ? "photo" : "photos"}`);
-  if (videos.value.length > 0)
-    parts.push(`${videos.value.length} ${videos.value.length === 1 ? "video" : "videos"}`);
+  if (photos > 0) parts.push(`${photos} ${photos === 1 ? "photo" : "photos"}`);
+  if (videos > 0) parts.push(`${videos} ${videos === 1 ? "video" : "videos"}`);
   return parts.join(" and ");
 });
 </script>
@@ -27,10 +29,12 @@ const summary = computed(() => {
     :ui="{ footer: 'justify-end' }"
   >
     <template #body>
-      <WatermarkSettingsForm v-if="photos.length > 0" :preview-src="previewSrc" />
-      <p v-else class="text-sm text-muted">
-        Videos transfer untouched. Watermarking currently applies to photos only.
-      </p>
+      <WatermarkSettingsForm
+        v-if="scope.watermarkable.length > 0"
+        :preview-src="previewSrc"
+        :note
+      />
+      <p v-else class="text-sm text-muted">{{ note }}</p>
     </template>
 
     <template #footer>

--- a/app/components/WatermarkSettingsForm.vue
+++ b/app/components/WatermarkSettingsForm.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { WATERMARK_POSITIONS, type WatermarkPosition } from "~/utils/watermark";
 
-defineProps<{ previewSrc?: string }>();
+const {
+  note = "The official watermark is rendered into JPEG photos. RAW files and videos transfer untouched.",
+} = defineProps<{ previewSrc?: string; note?: string }>();
 
 const { settings } = useWatermarkSettings();
 
@@ -24,11 +26,7 @@ const anchorClasses: Record<WatermarkPosition, string> = {
 
 <template>
   <div class="space-y-5">
-    <USwitch
-      v-model="settings.enabled"
-      label="Apply Luna Ultra watermark"
-      description="The official watermark is rendered into photos. Videos transfer untouched."
-    />
+    <USwitch v-model="settings.enabled" label="Apply Luna Ultra watermark" :description="note" />
 
     <div v-if="settings.enabled" class="grid grid-cols-[1fr_auto] items-start gap-4">
       <WatermarkCanvas :src="previewSrc" />

--- a/app/composables/useDownloads.ts
+++ b/app/composables/useDownloads.ts
@@ -1,4 +1,5 @@
 import type { DownloadEntry, MediaItem } from "~/types/media";
+import { canWatermark, watermarkNote, watermarkScope } from "~/utils/watermark";
 import { renderWatermarked } from "~/utils/watermarkClient";
 import { saveBlob } from "~/utils/saveFile";
 import { getCameraTransport } from "~/utils/transport";
@@ -33,7 +34,9 @@ export function useDownloads() {
         patch(entry.id, { progress: 45 });
         let blob = await response.blob();
         patch(entry.id, { progress: 70 });
-        if (entry.watermarked && entry.item.type === "photo") {
+        // Renderable photos only: RAW is `type: "photo"` too, but the canvas
+        // pipeline cannot decode it, so it saves unmodified (issue #2).
+        if (entry.watermarked && canWatermark(entry.item)) {
           blob = await renderWatermarked(blob, settings.value);
         }
         patch(entry.id, { progress: 90 });
@@ -70,9 +73,10 @@ export function useDownloads() {
       startedAt: stamp + index,
     }));
     queue.value = [...entries, ...queue.value];
+    const scope = watermarkScope(items);
     toast.add({
       title: `Downloading ${items.length} ${items.length === 1 ? "file" : "files"}`,
-      description: options.watermark ? "Watermark will be applied to photos" : undefined,
+      description: options.watermark ? watermarkNote(scope) : undefined,
       icon: "i-lucide-arrow-down-to-line",
     });
     if (!running.value) {

--- a/app/pages/downloads.vue
+++ b/app/pages/downloads.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatBytes } from "~/utils/media";
+import { canWatermark } from "~/utils/watermark";
 
 useHead({ title: "Downloads" });
 
@@ -76,7 +77,7 @@ const hasFinished = computed(() =>
             <div class="flex items-center gap-2">
               <p class="truncate font-mono text-sm text-highlighted">{{ entry.item.name }}</p>
               <UBadge
-                v-if="entry.watermarked && entry.item.type === 'photo'"
+                v-if="entry.watermarked && canWatermark(entry.item)"
                 variant="subtle"
                 size="sm"
                 icon="i-lucide-stamp"

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -121,7 +121,7 @@ useHead({ title: "Settings" });
           <div class="space-y-1">
             <h2 class="text-sm font-semibold text-highlighted">Watermark</h2>
             <p class="text-sm text-muted">
-              Applied to photos as they download. Videos transfer untouched.
+              Applied to JPEG photos as they download. RAW files and videos transfer untouched.
             </p>
           </div>
 

--- a/app/utils/watermark.ts
+++ b/app/utils/watermark.ts
@@ -1,3 +1,4 @@
+import type { MediaItem } from "~/types/media";
 import { LUNA_WATERMARK_LAYOUT } from "./watermarkLayout";
 
 export type WatermarkPosition =
@@ -42,6 +43,57 @@ export const DEFAULT_WATERMARK: WatermarkSettings = {
   enabled: true,
   position: "bottom-left",
 };
+
+/**
+ * Whether the watermark can be burned into this file at all.
+ *
+ * The pipeline is canvas-based — `createImageBitmap`, draw, re-encode to JPEG —
+ * so it only works on files the browser can decode. RAW (`.dng`) is
+ * `type: "photo"` but `renderable: false`: no engine decodes a raw Bayer frame,
+ * and watermarking one would mean demosaicing it into a JPEG, i.e. not
+ * returning the file the user asked for. Those save unmodified instead.
+ */
+export function canWatermark(item: MediaItem): boolean {
+  return item.type === "photo" && item.renderable;
+}
+
+/** A selection split by what watermarking can actually do to each file. */
+export interface WatermarkScope {
+  /** Renderable photos — the watermark is burned into these. */
+  watermarkable: MediaItem[];
+  /** RAW photos, saved byte-for-byte whatever the watermark setting says. */
+  raw: MediaItem[];
+  /** Videos, likewise untouched. */
+  videos: MediaItem[];
+}
+
+/** Split `items` so the UI can say honestly which files get a watermark. */
+export function watermarkScope(items: MediaItem[]): WatermarkScope {
+  const scope: WatermarkScope = { watermarkable: [], raw: [], videos: [] };
+  for (const item of items) {
+    if (item.type === "video") scope.videos.push(item);
+    else if (canWatermark(item)) scope.watermarkable.push(item);
+    else scope.raw.push(item);
+  }
+  return scope;
+}
+
+/**
+ * One honest sentence about what the watermark will do to this selection.
+ *
+ * Shared by the download modal and the queue toast so neither can drift into
+ * promising a watermark on files that will be saved untouched.
+ */
+export function watermarkNote(scope: WatermarkScope): string {
+  if (scope.watermarkable.length > 0) {
+    return scope.raw.length > 0
+      ? "Watermark will be applied to JPEG photos; RAW files are saved unmodified."
+      : "Watermark will be applied to photos.";
+  }
+  return scope.raw.length > 0
+    ? "RAW files are saved unmodified; watermarking applies to JPEG photos only."
+    : "Videos transfer untouched; watermarking applies to JPEG photos only.";
+}
 
 /** Snap an image to the closest aspect ratio in the official layout table. */
 export function nearestAspect(width: number, height: number): string {

--- a/app/utils/watermarkClient.ts
+++ b/app/utils/watermarkClient.ts
@@ -15,7 +15,7 @@ import type { WatermarkRequest, WatermarkResponse } from "~/workers/watermark.wo
  * original main-thread path rather than failing the download.
  */
 
-/** Which route the last render actually took. */
+/** Which route the last render actually took; `passthrough` means "off". */
 export type WatermarkPath = "worker" | "main-thread" | "passthrough";
 
 let lastPath: WatermarkPath = "passthrough";
@@ -102,20 +102,30 @@ async function renderOnMainThread(blob: Blob, settings: WatermarkSettings): Prom
   const context = canvas.getContext("2d");
   if (!context) {
     bitmap.close();
-    return blob;
+    throw new Error("Canvas 2D context unavailable");
   }
   context.drawImage(bitmap, 0, 0);
   await drawWatermark(context, bitmap.width, bitmap.height, settings);
   bitmap.close();
-  return await new Promise<Blob>((resolve) => {
-    canvas.toBlob((out) => resolve(out ?? blob), "image/jpeg", WATERMARK_JPEG_QUALITY);
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (out) => (out ? resolve(out) : reject(new Error("Watermark encode produced no data"))),
+      "image/jpeg",
+      WATERMARK_JPEG_QUALITY,
+    );
   });
 }
 
 /**
  * Return `blob` with the watermark applied. Returns the original untouched
- * when watermarking is off — no point paying a re-encode to change nothing —
- * and on any rendering failure, so a download never fails over decoration.
+ * only when watermarking is off — no point paying a re-encode to change
+ * nothing.
+ *
+ * A failure in both render paths throws. It used to return the original blob,
+ * which meant a download the user asked to watermark could report success with
+ * an unwatermarked file on disk (issue #2, where RAW reached here at all).
+ * Callers must not send files `canWatermark()` rejects; anything else failing
+ * is a genuine render fault and a silent success would be a lie.
  */
 export async function renderWatermarked(blob: Blob, settings: WatermarkSettings): Promise<Blob> {
   if (!settings.enabled) {
@@ -134,12 +144,7 @@ export async function renderWatermarked(blob: Blob, settings: WatermarkSettings)
     }
   }
 
-  try {
-    const out = await renderOnMainThread(blob, settings);
-    lastPath = "main-thread";
-    return out;
-  } catch {
-    lastPath = "passthrough";
-    return blob;
-  }
+  const out = await renderOnMainThread(blob, settings);
+  lastPath = "main-thread";
+  return out;
 }

--- a/tests/nuxt/useDownloads.test.ts
+++ b/tests/nuxt/useDownloads.test.ts
@@ -1,0 +1,93 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DownloadEntry } from "~/types/media";
+import { resetCameraTransport, setCameraTransport } from "~/utils/transport";
+import { makeFakeTransport } from "../helpers/fakeTransport";
+import { makeMediaItem } from "../helpers/media";
+import { mountComposable } from "./harness";
+
+const renderWatermarked = vi.hoisted(() => vi.fn(async (blob: Blob) => blob));
+const saveBlob = vi.hoisted(() => vi.fn(async () => "Downloads/Luna Ultra/file"));
+
+vi.mock("~/utils/watermarkClient", () => ({ renderWatermarked }));
+vi.mock("~/utils/saveFile", () => ({ saveBlob, isTauri: () => false }));
+
+mockNuxtImport("useToast", () => () => ({
+  add: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  clear: vi.fn(),
+  toasts: [],
+}));
+
+/** Wait for the queue drain kicked off by `enqueue` to settle. */
+async function settled(queue: { value: DownloadEntry[] }): Promise<void> {
+  for (let tick = 0; tick < 50; tick++) {
+    if (queue.value.every((entry) => entry.status === "done" || entry.status === "error")) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("useDownloads", () => {
+  beforeEach(() => {
+    renderWatermarked.mockClear();
+    saveBlob.mockClear();
+    setCameraTransport(
+      makeFakeTransport({
+        fetch: vi.fn(async () => new Response(new Blob(["photo-bytes"]), { status: 200 })),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    resetCameraTransport();
+    clearNuxtState(["download-queue", "download-running", "watermark-settings"], { reset: true });
+  });
+
+  it("watermarks renderable photos", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" })], { watermark: true });
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).toHaveBeenCalledTimes(1);
+    expect(downloads.queue.value[0]?.status).toBe("done");
+  });
+
+  it("saves RAW photos unmodified instead of pretending to watermark them", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue(
+      [makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false })],
+      { watermark: true },
+    );
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).not.toHaveBeenCalled();
+    expect(saveBlob).toHaveBeenCalledTimes(1);
+    expect(downloads.queue.value[0]?.status).toBe("done");
+  });
+
+  it("never watermarks videos", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video" })], {
+      watermark: true,
+    });
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).not.toHaveBeenCalled();
+  });
+
+  it("fails the download when watermarking a renderable photo throws", async () => {
+    renderWatermarked.mockRejectedValueOnce(new Error("watermark render failed"));
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" })], { watermark: true });
+    await settled(downloads.queue);
+
+    expect(saveBlob).not.toHaveBeenCalled();
+    expect(downloads.queue.value[0]?.status).toBe("error");
+    expect(downloads.queue.value[0]?.error).toBe("watermark render failed");
+  });
+});

--- a/tests/watermark.test.ts
+++ b/tests/watermark.test.ts
@@ -3,10 +3,14 @@ import {
   DEFAULT_WATERMARK,
   WATERMARK_ASSET_RATIO,
   WATERMARK_POSITIONS,
+  canWatermark,
   nearestAspect,
+  watermarkNote,
   watermarkRect,
+  watermarkScope,
 } from "~/utils/watermark";
 import { LUNA_WATERMARK_LAYOUT } from "~/utils/watermarkLayout";
+import { makeMediaItem } from "./helpers/media";
 
 describe("nearestAspect", () => {
   it("matches exact aspect ratios", () => {
@@ -62,5 +66,76 @@ describe("layout table", () => {
   it("defaults to the official bottom-left placement", () => {
     expect(DEFAULT_WATERMARK.position).toBe("bottom-left");
     expect(DEFAULT_WATERMARK.enabled).toBe(true);
+  });
+});
+
+describe("canWatermark", () => {
+  it("accepts renderable photos", () => {
+    expect(canWatermark(makeMediaItem({ ext: "jpg", renderable: true }))).toBe(true);
+  });
+
+  it("rejects RAW photos the canvas pipeline cannot decode", () => {
+    const dng = makeMediaItem({ name: "IMG_0001.dng", ext: "dng", renderable: false });
+    expect(canWatermark(dng)).toBe(false);
+  });
+
+  it("rejects RAW photos even when a sibling JPEG stands in for the preview", () => {
+    const dng = makeMediaItem({
+      name: "IMG_0001.dng",
+      ext: "dng",
+      renderable: false,
+      previewUrl: "http://127.0.0.1/DCIM/Camera01/IMG_0001.jpg",
+    });
+    expect(canWatermark(dng)).toBe(false);
+  });
+
+  it("rejects videos", () => {
+    expect(canWatermark(makeMediaItem({ type: "video", ext: "mp4" }))).toBe(false);
+  });
+});
+
+describe("watermarkScope", () => {
+  it("splits a mixed selection into watermarkable photos, raw photos and videos", () => {
+    const jpeg = makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" });
+    const raw = makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false });
+    const video = makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video", ext: "mp4" });
+
+    const scope = watermarkScope([jpeg, raw, video]);
+
+    expect(scope.watermarkable).toEqual([jpeg]);
+    expect(scope.raw).toEqual([raw]);
+    expect(scope.videos).toEqual([video]);
+  });
+
+  it("reports an empty scope for an empty selection", () => {
+    expect(watermarkScope([])).toEqual({ watermarkable: [], raw: [], videos: [] });
+  });
+});
+
+describe("watermarkNote", () => {
+  const jpeg = makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" });
+  const raw = makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false });
+  const video = makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video", ext: "mp4" });
+
+  it("promises the watermark without qualification when every photo is renderable", () => {
+    expect(watermarkNote(watermarkScope([jpeg]))).toBe("Watermark will be applied to photos.");
+  });
+
+  it("says RAW is left alone when the selection mixes JPEG and RAW", () => {
+    expect(watermarkNote(watermarkScope([jpeg, raw]))).toBe(
+      "Watermark will be applied to JPEG photos; RAW files are saved unmodified.",
+    );
+  });
+
+  it("promises nothing when the selection is RAW only", () => {
+    const note = watermarkNote(watermarkScope([raw]));
+    expect(note).toBe("RAW files are saved unmodified; watermarking applies to JPEG photos only.");
+    expect(note).not.toMatch(/will be applied/);
+  });
+
+  it("promises nothing when the selection is videos only", () => {
+    expect(watermarkNote(watermarkScope([video]))).toBe(
+      "Videos transfer untouched; watermarking applies to JPEG photos only.",
+    );
   });
 });

--- a/tests/watermarkClient.test.ts
+++ b/tests/watermarkClient.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_WATERMARK, type WatermarkSettings } from "~/utils/watermark";
+import { lastWatermarkPath, renderWatermarked } from "~/utils/watermarkClient";
+
+/**
+ * No Worker, no OffscreenCanvas and no createImageBitmap here, so every render
+ * attempt takes the main-thread path and fails there — which is exactly the
+ * shape of the RAW failure this file guards against being swallowed.
+ */
+const OFF: WatermarkSettings = { ...DEFAULT_WATERMARK, enabled: false };
+
+function photoBlob(): Blob {
+  return new Blob([new Uint8Array([0xff, 0xd8, 0xff])], { type: "image/jpeg" });
+}
+
+describe("renderWatermarked", () => {
+  it("returns the original blob untouched when watermarking is off", async () => {
+    const blob = photoBlob();
+    await expect(renderWatermarked(blob, OFF)).resolves.toBe(blob);
+    expect(lastWatermarkPath()).toBe("passthrough");
+  });
+
+  it("rejects instead of silently returning an unwatermarked blob when the render fails", async () => {
+    await expect(renderWatermarked(photoBlob(), DEFAULT_WATERMARK)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #2.

## Problem

Downloading a `.dng` with watermarking enabled saved the file **without** a watermark and reported success, so nothing indicated the watermark had been dropped.

`useDownloads.processNext` gated on file type alone (`entry.item.type === "photo"`). A DNG is `type: "photo"` but `renderable: false`, so RAW took that branch — and the whole watermark pipeline is canvas-based, starting from `createImageBitmap`, which no engine can do to a raw Bayer frame. The rejection fell through the worker, through the main-thread retry, and into a `catch` that returned the original blob.

## Fix — option 1 from the issue

Watermarking now applies to renderable photos only, and the UI says so.

New `app/utils/watermark.ts` holds the decision in one place:
- `canWatermark(item)` — `type === "photo" && item.renderable`
- `watermarkScope(items)` — splits a selection into watermarkable / raw / videos
- `watermarkNote(scope)` — the one honest sentence, shared by every surface so they can't drift apart

Burning a watermark into a DNG isn't meaningful anyway: it would mean demosaicing and re-encoding to JPEG, i.e. not returning the file the user asked for.

### Three related lies this also fixes

Beyond the call site named in the issue, the same wrong test appeared in:
- `downloads.vue` — a DNG row was labelled with a "Watermarked" badge
- `DownloadOptionsModal` — the watermark preview could be handed a DNG's `srcUrl`; it now picks the first *renderable* photo
- `settings.vue` — section copy made the same promise

### Behaviour change worth flagging

The silent passthrough in `watermarkClient.ts` is gone. Once RAW is excluded, anything still failing is a genuine render fault on a file we *told the user* we'd watermark, and returning the original blob just relocates the same lie. `renderWatermarked` now propagates and `useDownloads`' existing catch marks the entry as errored (visible, retryable). Two smaller instances of the same shape inside `renderOnMainThread` — a missing 2D context, a `toBlob` returning null — now throw rather than silently returning the original.

The worker → main-thread fallback is untouched; that's a legitimate degradation, not a failure. `lastWatermarkPath()`'s `"passthrough"` now means exactly one thing: watermarking is off.

## Tests

13 cases written first and confirmed red (7 node + 1 nuxt failing, including one showing `renderWatermarked` being called on a DNG), across `tests/watermark.test.ts`, new `tests/watermarkClient.test.ts`, and new `tests/nuxt/useDownloads.test.ts`.

`bun run test`, `bun run lint` and `bun run typecheck` all pass.

> Note: this and #5 both add `tests/nuxt/useDownloads.test.ts` and both touch `processNext`. Whichever merges second will need the two sets of cases combined — the resolution is straightforward, and `recordSize` must stay *before* the watermark gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)