### PR TITLE
feat(camera): add a live histogram overlay to the viewfinder

### DIFF
--- a/app/components/CameraHistogram.vue
+++ b/app/components/CameraHistogram.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { HISTOGRAM_BINS, type Histogram } from "~/utils/histogram";
+
+const { mode, histogram, available, cycle } = useHistogram();
+
+const canvas = useTemplateRef<HTMLCanvasElement>("canvas");
+
+/** Drawn size in CSS pixels. Small: this is an engraving, not a panel. */
+const WIDTH = 112;
+const HEIGHT = 44;
+
+/** Below this share of the frame, clipping is noise rather than a warning. */
+const CLIP_THRESHOLD = 0.002;
+
+const label = computed(() => (mode.value === "rgb" ? "RGB" : "LUM"));
+
+const clippedHighlights = computed(() => histogram.value.clippedHighlights > CLIP_THRESHOLD);
+const clippedShadows = computed(() => histogram.value.clippedShadows > CLIP_THRESHOLD);
+
+const title = computed(() =>
+  mode.value === "luma" ? "Histogram: luma. Click for RGB." : "Histogram: RGB. Click to hide.",
+);
+
+/**
+ * Square-root scaling rather than linear. A large flat area — sky, a wall —
+ * puts one bin an order of magnitude above the rest, and under linear scaling
+ * that spike flattens everything else to an invisible line. Any monotonic
+ * curve preserves the two things you actually read off a histogram (where the
+ * data sits, and whether it touches a rail), and this one keeps sparse
+ * highlight detail visible, which is the part you most need to see.
+ */
+function barHeight(count: number, peak: number) {
+  if (peak <= 0) return 0;
+  return Math.sqrt(count / peak) * HEIGHT;
+}
+
+function drawChannel(
+  context: CanvasRenderingContext2D,
+  bins: Uint32Array,
+  peak: number,
+  style: string,
+) {
+  context.fillStyle = style;
+  const binWidth = WIDTH / HISTOGRAM_BINS;
+  for (let bin = 0; bin < HISTOGRAM_BINS; bin++) {
+    const height = barHeight(bins[bin]!, peak);
+    if (height <= 0) continue;
+    context.fillRect(bin * binWidth, HEIGHT - height, binWidth, height);
+  }
+}
+
+function draw(data: Histogram) {
+  const element = canvas.value;
+  if (!element) return;
+
+  // Back the canvas at device resolution so 256 bins across 112px stay crisp.
+  const ratio = window.devicePixelRatio || 1;
+  const backingWidth = Math.round(WIDTH * ratio);
+  const backingHeight = Math.round(HEIGHT * ratio);
+  if (element.width !== backingWidth) element.width = backingWidth;
+  if (element.height !== backingHeight) element.height = backingHeight;
+
+  const context = element.getContext("2d");
+  if (!context) return;
+
+  context.setTransform(ratio, 0, 0, ratio, 0, 0);
+  context.clearRect(0, 0, WIDTH, HEIGHT);
+
+  // Quarter-stop guides, so you can place the data rather than just see it.
+  context.fillStyle = "rgba(255,255,255,0.12)";
+  for (let quarter = 1; quarter < 4; quarter++) {
+    context.fillRect(Math.round((WIDTH * quarter) / 4), 0, 1, HEIGHT);
+  }
+
+  if (data.total === 0) return;
+
+  if (mode.value === "rgb") {
+    // Additive, so overlapping channels read white exactly where they agree.
+    context.globalCompositeOperation = "lighter";
+    drawChannel(context, data.r, data.peak, "rgba(255,64,64,0.75)");
+    drawChannel(context, data.g, data.peak, "rgba(64,255,64,0.75)");
+    drawChannel(context, data.b, data.peak, "rgba(64,128,255,0.75)");
+    context.globalCompositeOperation = "source-over";
+  } else {
+    drawChannel(context, data.luma, data.peak, "rgba(255,255,255,0.8)");
+  }
+}
+
+watch([histogram, mode], ([data]) => draw(data), { flush: "post" });
+onMounted(() => draw(histogram.value));
+</script>
+
+<template>
+  <!--
+    The scrim above is pointer-events-none so it never eats viewfinder input;
+    this control opts itself back in.
+  -->
+  <div v-if="available" class="pointer-events-auto flex items-end gap-2">
+    <UButton
+      v-if="mode === 'off'"
+      icon="i-lucide-chart-column"
+      color="neutral"
+      variant="ghost"
+      size="xs"
+      aria-label="Show histogram"
+      title="Show histogram"
+      @click="cycle"
+    />
+
+    <button
+      v-else
+      type="button"
+      class="flex cursor-pointer flex-col items-end gap-1 rounded-md bg-black/40 p-1.5 transition-colors hover:bg-black/60"
+      :aria-label="title"
+      :title
+      @click="cycle"
+    >
+      <div class="relative">
+        <canvas
+          ref="canvas"
+          :style="{ width: `${WIDTH}px`, height: `${HEIGHT}px` }"
+          class="block"
+        />
+        <!--
+          Clipping rails. Red is spoken for in this interface — it means
+          recording, and nothing else may wear it — so blown highlights are
+          amber and crushed shadows are blue.
+        -->
+        <span
+          v-show="clippedShadows"
+          class="absolute inset-y-0 left-0 w-0.5 bg-sky-400"
+          aria-hidden="true"
+        />
+        <span
+          v-show="clippedHighlights"
+          class="absolute inset-y-0 right-0 w-0.5 bg-amber-400"
+          aria-hidden="true"
+        />
+      </div>
+      <span class="font-mono text-[10px] leading-none tracking-wider text-white/50">{{
+        label
+      }}</span>
+    </button>
+  </div>
+</template>

--- a/app/components/LiveView.vue
+++ b/app/components/LiveView.vue
@@ -1,12 +1,59 @@
 <script setup lang="ts">
 import { buildCodecString, detectCodec, drainAccessUnits, splitNalUnits } from "~/utils/annexB";
 import type { NalCodec } from "~/utils/annexB";
+import {
+  computeHistogram,
+  HISTOGRAM_SAMPLE_EVERY,
+  HISTOGRAM_SAMPLE_HEIGHT,
+  HISTOGRAM_SAMPLE_WIDTH,
+} from "~/utils/histogram";
 
 // The page owns starting and stopping the stream; this component is just the
 // decoding surface for whatever the live-view composable is currently serving.
 const { active, transport, streamUrl, error, note, stop } = useLiveView();
 
+// A VideoFrame is only readable between decode and close, so the histogram is
+// sampled here and pushed out, rather than the composable reaching in for it.
+const { sampling, publish: publishHistogram } = useHistogram();
+
 const canvas = useTemplateRef<HTMLCanvasElement>("canvas");
+
+/** Offscreen scratch the frame is subsampled into before it is binned. */
+let sampleCanvas: HTMLCanvasElement | null = null;
+let sampleContext: CanvasRenderingContext2D | null = null;
+let frameIndex = 0;
+
+/**
+ * Bin a decoded frame for the viewfinder histogram.
+ *
+ * The frame is drawn into a small scratch canvas with smoothing *off*. That
+ * matters: scaling 1280x960 down with the browser's default smoothing averages
+ * neighbouring pixels, so a blown highlight next to a mid-grey one lands near
+ * 200 instead of 255 and the clipping you needed to see disappears. Nearest
+ * neighbour takes real pixel values, and 128x96 of them is plenty of sample to
+ * hold the shape of a scene.
+ */
+function sampleHistogram(frame: VideoFrame) {
+  if (frameIndex++ % HISTOGRAM_SAMPLE_EVERY !== 0) return;
+
+  if (!sampleCanvas) {
+    sampleCanvas = document.createElement("canvas");
+    sampleCanvas.width = HISTOGRAM_SAMPLE_WIDTH;
+    sampleCanvas.height = HISTOGRAM_SAMPLE_HEIGHT;
+    sampleContext = sampleCanvas.getContext("2d", { willReadFrequently: true });
+    if (sampleContext) sampleContext.imageSmoothingEnabled = false;
+  }
+  if (!sampleContext) return;
+
+  sampleContext.drawImage(frame, 0, 0, HISTOGRAM_SAMPLE_WIDTH, HISTOGRAM_SAMPLE_HEIGHT);
+  const { data } = sampleContext.getImageData(
+    0,
+    0,
+    HISTOGRAM_SAMPLE_WIDTH,
+    HISTOGRAM_SAMPLE_HEIGHT,
+  );
+  publishHistogram(computeHistogram(data));
+}
 let decoder: VideoDecoder | null = null;
 let abort: AbortController | null = null;
 
@@ -28,6 +75,9 @@ function paint(frame: VideoFrame) {
   if (element.width !== frame.displayWidth) element.width = frame.displayWidth;
   if (element.height !== frame.displayHeight) element.height = frame.displayHeight;
   element.getContext("2d")?.drawImage(frame, 0, 0);
+  // Sample before closing: after this the frame's pixels are gone. Guarded so
+  // a hidden histogram costs nothing at all.
+  if (sampling.value) sampleHistogram(frame);
   frame.close();
 }
 
@@ -120,6 +170,7 @@ function reset() {
   resetDecoderState();
   carry = new Uint8Array(0);
   timestamp = 0;
+  frameIndex = 0;
 }
 
 /**

--- a/app/composables/useHistogram.ts
+++ b/app/composables/useHistogram.ts
@@ -1,0 +1,63 @@
+import {
+  cycleHistogramMode,
+  emptyHistogram,
+  HISTOGRAM_MODES,
+  type Histogram,
+  type HistogramMode,
+} from "~/utils/histogram";
+
+const STORAGE_KEY = "luna-histogram-mode-v1";
+
+/**
+ * Which viewfinder overlay is showing, and the latest binned frame behind it.
+ *
+ * The composable deliberately knows nothing about WebCodecs: `LiveView` owns
+ * the `VideoFrame` and pushes results in through `publish`, because a frame is
+ * only readable between decode and `close()`.
+ */
+export function useHistogram() {
+  const state = useState<HistogramMode>("histogram-mode", () => {
+    if (import.meta.client) {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && (HISTOGRAM_MODES as readonly string[]).includes(stored)) {
+        return stored as HistogramMode;
+      }
+    }
+    return "off";
+  });
+
+  const histogram = useState<Histogram>("histogram-data", () => emptyHistogram());
+
+  // Written in `cycle` rather than through a `watch`. The mode only ever
+  // changes there, so a watcher would be indirection for nothing — and it
+  // would be a *per-call-site* effect on shared state, which is how you end up
+  // with one component's teardown writing over another's.
+  const mode = computed(() => state.value);
+
+  const { transport } = useLiveView();
+
+  /**
+   * Only the Annex-B path can be measured. The MJPEG fallback is an `<img>`
+   * pointed at the camera's own host, so reading it back taints the canvas.
+   * The overlay hides itself rather than showing an empty box.
+   */
+  const available = computed(() => transport.value === "annexb");
+
+  /** True when there is a reason to spend pixel reads on the next frame. */
+  const sampling = computed(() => available.value && mode.value !== "off");
+
+  function publish(next: Histogram) {
+    histogram.value = next;
+  }
+
+  function cycle() {
+    const next = cycleHistogramMode(state.value);
+    state.value = next;
+    if (import.meta.client) localStorage.setItem(STORAGE_KEY, next);
+    // Drop the last reading on the way out, so re-opening the overlay cannot
+    // flash a curve from a scene the camera is no longer pointed at.
+    if (next === "off") histogram.value = emptyHistogram();
+  }
+
+  return { mode, histogram, available, sampling, publish, cycle };
+}

--- a/app/pages/camera.vue
+++ b/app/pages/camera.vue
@@ -181,7 +181,7 @@ const topError = computed(() => liveError.value ?? error.value ?? null);
             class="pointer-events-none absolute inset-x-0 top-0 z-10 bg-gradient-to-b from-black/70 via-black/30 to-transparent pb-8"
           >
             <div
-              class="flex items-start justify-between gap-4 p-4 pr-12 font-mono text-[11px] text-white/70"
+              class="flex items-start justify-between gap-4 p-4 pr-14 font-mono text-[11px] text-white/70"
             >
               <div class="flex items-center gap-3">
                 <!--
@@ -197,20 +197,28 @@ const topError = computed(() => liveError.value ?? error.value ?? null);
                 <span v-if="storage" class="tracking-wider">{{ storage.toFixed(1) }} GB</span>
               </div>
 
-              <div class="flex items-center gap-3 text-right">
-                <span v-if="activeFilter" class="tracking-wider text-white">{{
-                  activeFilter
-                }}</span>
-                <span v-if="colorMode" class="tracking-wider">{{ colorMode }}</span>
-                <span v-if="resolution" class="tracking-wider">{{ resolution }}</span>
-                <span
-                  v-if="battery !== null"
-                  class="flex items-center gap-1 tabular-nums tracking-wider"
-                  :class="batteryClass"
-                >
-                  <UIcon name="i-lucide-battery" class="size-3.5" />
-                  {{ battery }}%
-                </span>
+              <!--
+                The readouts keep their single line; the histogram hangs below
+                them on the same right rail, clear of the zoom dial's column.
+              -->
+              <div class="flex flex-col items-end gap-2 text-right">
+                <div class="flex items-center gap-3">
+                  <span v-if="activeFilter" class="tracking-wider text-white">{{
+                    activeFilter
+                  }}</span>
+                  <span v-if="colorMode" class="tracking-wider">{{ colorMode }}</span>
+                  <span v-if="resolution" class="tracking-wider">{{ resolution }}</span>
+                  <span
+                    v-if="battery !== null"
+                    class="flex items-center gap-1 tabular-nums tracking-wider"
+                    :class="batteryClass"
+                  >
+                    <UIcon name="i-lucide-battery" class="size-3.5" />
+                    {{ battery }}%
+                  </span>
+                </div>
+
+                <CameraHistogram />
               </div>
             </div>
           </div>

--- a/app/utils/histogram.ts
+++ b/app/utils/histogram.ts
@@ -1,0 +1,112 @@
+/**
+ * Histogram maths for the live viewfinder. Pure and DOM-free on purpose: the
+ * only thing that may touch a `VideoFrame` is the decode surface, and keeping
+ * the arithmetic out here is what makes it testable without WebCodecs.
+ */
+
+/** One bin per 8-bit code value, so a bin index *is* the sample value. */
+export const HISTOGRAM_BINS = 256;
+
+/**
+ * Sample at a third of the ~30fps preview. A histogram redrawing thirty times
+ * a second is a shimmer rather than a reading, and no scene changes shape fast
+ * enough to be worth the pixel reads.
+ */
+export const HISTOGRAM_SAMPLE_EVERY = 3;
+
+/** Sample grid: small enough to read every frame, dense enough to hold a shape. */
+export const HISTOGRAM_SAMPLE_WIDTH = 128;
+export const HISTOGRAM_SAMPLE_HEIGHT = 96;
+
+export const HISTOGRAM_MODES = ["off", "luma", "rgb"] as const;
+export type HistogramMode = (typeof HISTOGRAM_MODES)[number];
+
+export interface Histogram {
+  r: Uint32Array;
+  g: Uint32Array;
+  b: Uint32Array;
+  luma: Uint32Array;
+  /** Pixels sampled. Zero when there is nothing to show yet. */
+  total: number;
+  /** Tallest bin across every channel, so the renderer can scale in one read. */
+  peak: number;
+  /** Share of pixels with any channel at 0, as a fraction of `total`. */
+  clippedShadows: number;
+  /** Share of pixels with any channel at 255, as a fraction of `total`. */
+  clippedHighlights: number;
+}
+
+/**
+ * Rec.709 luma coefficients. The preview is HD video, so this is the transfer
+ * it is actually encoded in — a flat (r+g+b)/3 would read greens as far darker
+ * and reds as far brighter than they expose, which is the one error an
+ * exposure tool must not make.
+ */
+const R_WEIGHT = 0.2126;
+const G_WEIGHT = 0.7152;
+const B_WEIGHT = 0.0722;
+
+export function emptyHistogram(): Histogram {
+  return {
+    r: new Uint32Array(HISTOGRAM_BINS),
+    g: new Uint32Array(HISTOGRAM_BINS),
+    b: new Uint32Array(HISTOGRAM_BINS),
+    luma: new Uint32Array(HISTOGRAM_BINS),
+    total: 0,
+    peak: 0,
+    clippedShadows: 0,
+    clippedHighlights: 0,
+  };
+}
+
+/**
+ * Bin an RGBA buffer — the layout `CanvasRenderingContext2D.getImageData`
+ * returns. Alpha is ignored: the preview is opaque, and a frame is not less
+ * exposed for being drawn translucent.
+ */
+export function computeHistogram(rgba: Uint8ClampedArray): Histogram {
+  const result = emptyHistogram();
+  const { r, g, b, luma } = result;
+
+  let total = 0;
+  let shadows = 0;
+  let highlights = 0;
+
+  for (let i = 0; i + 3 < rgba.length; i += 4) {
+    const red = rgba[i]!;
+    const green = rgba[i + 1]!;
+    const blue = rgba[i + 2]!;
+
+    r[red]!++;
+    g[green]!++;
+    b[blue]!++;
+    luma[Math.round(R_WEIGHT * red + G_WEIGHT * green + B_WEIGHT * blue)]!++;
+
+    // Any channel at a rail is clipped. Testing per channel rather than on
+    // luma is deliberate: a blown red on an otherwise mid-grey pixel is the
+    // failure you most need to see, and it never reaches 255 in luma.
+    if (red === 0 || green === 0 || blue === 0) shadows++;
+    if (red === 255 || green === 255 || blue === 255) highlights++;
+    total++;
+  }
+
+  let peak = 0;
+  for (let bin = 0; bin < HISTOGRAM_BINS; bin++) {
+    if (r[bin]! > peak) peak = r[bin]!;
+    if (g[bin]! > peak) peak = g[bin]!;
+    if (b[bin]! > peak) peak = b[bin]!;
+    if (luma[bin]! > peak) peak = luma[bin]!;
+  }
+
+  result.total = total;
+  result.peak = peak;
+  result.clippedShadows = total === 0 ? 0 : shadows / total;
+  result.clippedHighlights = total === 0 ? 0 : highlights / total;
+  return result;
+}
+
+/** off → luma → rgb → off. One control, in the order you reach for them. */
+export function cycleHistogramMode(mode: HistogramMode): HistogramMode {
+  const next = HISTOGRAM_MODES.indexOf(mode) + 1;
+  return HISTOGRAM_MODES[next % HISTOGRAM_MODES.length]!;
+}

--- a/tests/histogram.test.ts
+++ b/tests/histogram.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeHistogram,
+  cycleHistogramMode,
+  HISTOGRAM_BINS,
+  type HistogramMode,
+} from "~/utils/histogram";
+
+/** Build an RGBA buffer from a flat list of [r, g, b] triples. */
+const pixels = (...triples: [number, number, number][]) =>
+  new Uint8ClampedArray(triples.flatMap(([r, g, b]) => [r, g, b, 255]));
+
+/** Every bin that holds a non-zero count, as [bin, count] pairs. */
+const occupied = (bins: Uint32Array) =>
+  [...bins.entries()].filter(([, count]) => count > 0).map(([bin, count]) => [bin, count]);
+
+describe("computeHistogram", () => {
+  it("counts each channel into its own 256-bin array", () => {
+    const result = computeHistogram(pixels([10, 20, 30], [10, 200, 30]));
+
+    expect(result.r).toHaveLength(HISTOGRAM_BINS);
+    expect(occupied(result.r)).toEqual([[10, 2]]);
+    expect(occupied(result.g)).toEqual([
+      [20, 1],
+      [200, 1],
+    ]);
+    expect(occupied(result.b)).toEqual([[30, 2]]);
+  });
+
+  /**
+   * A flat (r+g+b)/3 average reads green as too dark and red as too bright,
+   * which is exactly the error that makes you misjudge an exposure. Rec.709 is
+   * the transfer the preview is actually encoded in.
+   */
+  it("weights luma by Rec.709 rather than averaging the channels", () => {
+    const green = computeHistogram(pixels([0, 255, 0]));
+    const red = computeHistogram(pixels([255, 0, 0]));
+    const blue = computeHistogram(pixels([0, 0, 255]));
+
+    expect(occupied(green.luma)).toEqual([[Math.round(0.7152 * 255), 1]]);
+    expect(occupied(red.luma)).toEqual([[Math.round(0.2126 * 255), 1]]);
+    expect(occupied(blue.luma)).toEqual([[Math.round(0.0722 * 255), 1]]);
+  });
+
+  it("puts pure black in bin 0 and pure white in bin 255", () => {
+    const result = computeHistogram(pixels([0, 0, 0], [255, 255, 255]));
+
+    expect(result.luma[0]).toBe(1);
+    expect(result.luma[HISTOGRAM_BINS - 1]).toBe(1);
+  });
+
+  it("reports clipping as a fraction of the sample, per end of the range", () => {
+    // 1 crushed, 3 blown, 4 mid-grey — of 8 total.
+    const result = computeHistogram(
+      pixels(
+        [0, 0, 0],
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 255],
+        [128, 128, 128],
+        [128, 128, 128],
+        [128, 128, 128],
+        [128, 128, 128],
+      ),
+    );
+
+    expect(result.clippedShadows).toBeCloseTo(1 / 8);
+    expect(result.clippedHighlights).toBeCloseTo(3 / 8);
+  });
+
+  /**
+   * A single blown channel is still blown — it is the case you most need to
+   * catch, and averaging into luma first would hide it.
+   */
+  it("counts a pixel as clipped when any single channel is at the rail", () => {
+    const result = computeHistogram(pixels([255, 10, 10], [10, 10, 0]));
+
+    expect(result.clippedHighlights).toBeCloseTo(1 / 2);
+    expect(result.clippedShadows).toBeCloseTo(1 / 2);
+  });
+
+  it("returns an all-zero histogram for an empty sample without dividing by zero", () => {
+    const result = computeHistogram(new Uint8ClampedArray(0));
+
+    expect(result.total).toBe(0);
+    expect(result.peak).toBe(0);
+    expect(result.clippedShadows).toBe(0);
+    expect(result.clippedHighlights).toBe(0);
+    expect(occupied(result.luma)).toEqual([]);
+  });
+
+  /**
+   * The renderer scales bar heights against `peak`. Taking it from the counts
+   * here keeps that a read rather than a second pass over 256 bins per frame.
+   */
+  it("reports the tallest bin across every channel it will draw", () => {
+    const result = computeHistogram(pixels([10, 20, 30], [10, 20, 40], [10, 99, 50]));
+
+    expect(result.total).toBe(3);
+    expect(result.peak).toBe(3); // red: three pixels share bin 10
+  });
+
+  it("ignores the alpha byte", () => {
+    const opaque = computeHistogram(new Uint8ClampedArray([10, 20, 30, 255]));
+    const transparent = computeHistogram(new Uint8ClampedArray([10, 20, 30, 0]));
+
+    expect(occupied(opaque.luma)).toEqual(occupied(transparent.luma));
+  });
+});
+
+describe("cycleHistogramMode", () => {
+  it("steps off to luma to rgb and back to off", () => {
+    const seen: HistogramMode[] = [];
+    let mode: HistogramMode = "off";
+    for (let i = 0; i < 4; i++) {
+      mode = cycleHistogramMode(mode);
+      seen.push(mode);
+    }
+
+    expect(seen).toEqual(["luma", "rgb", "off", "luma"]);
+  });
+});

--- a/tests/nuxt/useHistogram.test.ts
+++ b/tests/nuxt/useHistogram.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { computeHistogram } from "~/utils/histogram";
+import { mountComposable } from "./harness";
+
+const STATE_KEYS = ["histogram-mode", "histogram-data", "liveview-transport"];
+
+const mount = () =>
+  mountComposable(() => ({
+    hist: useHistogram(),
+    live: useLiveView(),
+  }));
+
+describe("useHistogram", () => {
+  beforeEach(() => {
+    // Storage first: `{ reset: true }` re-runs the state initializer as it
+    // clears, and that initializer reads storage. Clearing the other way round
+    // seeds each test from the previous test's persisted mode.
+    localStorage.clear();
+    clearNuxtState(STATE_KEYS, { reset: true });
+  });
+
+  afterEach(() => {
+    clearNuxtState(STATE_KEYS, { reset: true });
+  });
+
+  it("starts off", async () => {
+    const { hist } = await mount();
+
+    expect(hist.mode.value).toBe("off");
+  });
+
+  it("cycles off to luma to rgb and back, persisting each step", async () => {
+    const { hist } = await mount();
+
+    hist.cycle();
+    expect(hist.mode.value).toBe("luma");
+    expect(localStorage.getItem("luna-histogram-mode-v1")).toBe("luma");
+
+    hist.cycle();
+    expect(hist.mode.value).toBe("rgb");
+
+    hist.cycle();
+    expect(hist.mode.value).toBe("off");
+  });
+
+  it("restores a persisted mode", async () => {
+    // beforeEach re-runs the state initializer as it clears, so the stored
+    // value has to be planted and the state dropped again before mounting for
+    // the read path to be exercised at all.
+    localStorage.setItem("luna-histogram-mode-v1", "rgb");
+    clearNuxtState(["histogram-mode"]);
+    const { hist } = await mount();
+
+    expect(hist.mode.value).toBe("rgb");
+  });
+
+  it("ignores a persisted value that is not a mode", async () => {
+    localStorage.setItem("luna-histogram-mode-v1", "sideways");
+    clearNuxtState(["histogram-mode"]);
+    const { hist } = await mount();
+
+    expect(hist.mode.value).toBe("off");
+  });
+
+  /**
+   * The MJPEG fallback is an <img> on the camera's own origin, so reading it
+   * back would taint the canvas. Hiding beats showing an empty box.
+   */
+  it("is available only on the Annex-B transport", async () => {
+    const { hist, live } = await mount();
+
+    expect(hist.available.value).toBe(false);
+
+    live.transport.value = "mjpeg";
+    expect(hist.available.value).toBe(false);
+
+    live.transport.value = "annexb";
+    expect(hist.available.value).toBe(true);
+  });
+
+  it("only asks for samples when it is both available and switched on", async () => {
+    const { hist, live } = await mount();
+    live.transport.value = "annexb";
+
+    expect(hist.sampling.value).toBe(false);
+
+    hist.cycle();
+    expect(hist.sampling.value).toBe(true);
+
+    live.transport.value = "mjpeg";
+    expect(hist.sampling.value).toBe(false);
+  });
+
+  it("clears the last reading when switched off, so a stale curve cannot linger", async () => {
+    const { hist, live } = await mount();
+    live.transport.value = "annexb";
+    hist.cycle();
+
+    hist.publish(computeHistogram(new Uint8ClampedArray([10, 20, 30, 255])));
+    expect(hist.histogram.value.total).toBe(1);
+
+    hist.cycle(); // rgb
+    expect(hist.histogram.value.total).toBe(1);
+
+    hist.cycle(); // off
+    expect(hist.histogram.value.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Exposure on the Luna is judged from a 1280x960 preview on a laptop screen — exactly the situation a histogram exists for. Clipped highlights and crushed shadows are invisible on a small bright panel and unrecoverable afterwards.

Three modes cycle from the viewfinder — **off**, **luma**, **RGB** — persisted to `localStorage` so the choice survives a reconnect.

## Design notes

**The maths is pure and DOM-free.** `app/utils/histogram.ts` has no WebCodecs and no canvas, so it's testable directly. `useHistogram` holds the mode and the latest reading; `LiveView` owns the `VideoFrame` and pushes results *in* via `publish`, because a frame is only readable between decode and `close()` — the composable can't reach in for it after the fact.

**Nearest-neighbour subsampling, deliberately.** Frames are drawn into a 128x96 scratch canvas with `imageSmoothingEnabled = false`. Default smoothing averages neighbouring pixels, so a blown highlight next to a mid-grey one lands near 200 instead of 255 — and the clipping you needed to see disappears. Nearest neighbour takes real pixel values, and 128x96 of them holds the shape of a scene fine.

**Rec.709 luma, not a flat mean.** The preview is HD video, so that's the transfer it's actually encoded in. `(r+g+b)/3` would read greens as far darker and reds as far brighter than they expose — the one error an exposure tool must not make.

**Sampled every third frame.** A histogram redrawing thirty times a second is a shimmer rather than a reading, and no scene changes shape that fast. Skipped entirely when the overlay is hidden, so an off histogram costs nothing.

Also nudges the viewfinder header padding (`pr-12` → `pr-14`) to make room for the toggle.

## Tests

`tests/histogram.test.ts` (9) — binning, Rec.709 weighting, clipping fractions, peak scaling, empty state, mode cycling.
`tests/nuxt/useHistogram.test.ts` (7) — mode persistence, publish/read, sampling gate.

`bun run test` (298 node + 19 nuxt), `bun run lint` and `bun run typecheck` all pass on this branch standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)