### PR TITLE
feat(downloads): show RAW previews derived from the downloaded bytes

### DIFF
--- a/app/components/DownloadOptionsModal.vue
+++ b/app/components/DownloadOptionsModal.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
 import type { MediaItem } from "~/types/media";
+import { watermarkNote, watermarkScope } from "~/utils/watermark";
 
 const props = defineProps<{ items: MediaItem[] }>();
 
 const emit = defineEmits<{ close: [confirmed: boolean] }>();
 
-const photos = computed(() => props.items.filter((item) => item.type === "photo"));
-const videos = computed(() => props.items.filter((item) => item.type === "video"));
-const previewSrc = computed(() => photos.value[0]?.srcUrl);
+const scope = computed(() => watermarkScope(props.items));
+const note = computed(() => watermarkNote(scope.value));
+// Only a renderable photo can stand in for the watermark preview.
+const previewSrc = computed(() => scope.value.watermarkable[0]?.srcUrl);
 
 const summary = computed(() => {
+  const photos = scope.value.watermarkable.length + scope.value.raw.length;
+  const videos = scope.value.videos.length;
   const parts: string[] = [];
-  if (photos.value.length > 0)
-    parts.push(`${photos.value.length} ${photos.value.length === 1 ? "photo" : "photos"}`);
-  if (videos.value.length > 0)
-    parts.push(`${videos.value.length} ${videos.value.length === 1 ? "video" : "videos"}`);
+  if (photos > 0) parts.push(`${photos} ${photos === 1 ? "photo" : "photos"}`);
+  if (videos > 0) parts.push(`${videos} ${videos === 1 ? "video" : "videos"}`);
   return parts.join(" and ");
 });
 </script>
@@ -27,10 +29,12 @@ const summary = computed(() => {
     :ui="{ footer: 'justify-end' }"
   >
     <template #body>
-      <WatermarkSettingsForm v-if="photos.length > 0" :preview-src="previewSrc" />
-      <p v-else class="text-sm text-muted">
-        Videos transfer untouched. Watermarking currently applies to photos only.
-      </p>
+      <WatermarkSettingsForm
+        v-if="scope.watermarkable.length > 0"
+        :preview-src="previewSrc"
+        :note
+      />
+      <p v-else class="text-sm text-muted">{{ note }}</p>
     </template>
 
     <template #footer>

--- a/app/components/RawImage.vue
+++ b/app/components/RawImage.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { getCameraTransport } from "~/utils/transport";
 import { extractDngPreview } from "~/utils/dng";
-import { parseRawImageMeta, decodeRawPreview } from "~/utils/rawPreview";
+import { decodeRawToDataUrl } from "~/utils/rawCanvas";
 import { formatBytes } from "~/utils/media";
 import { withCameraSlot, CAMERA_PRIORITY } from "~/utils/cameraQueue";
-import { cachedMedia } from "~/utils/mediaCache";
+import { cachedMedia, hasCachedMedia } from "~/utils/mediaCache";
+import { rawPreviewKey } from "~/utils/rawPreviewCache";
 
 /**
  * Shows a RAW (e.g. DNG) file. Prefers an embedded preview JPEG; when the file
@@ -23,6 +24,7 @@ const {
   eager = false,
   prefer = "largest",
   maxBytes,
+  cacheOnly = false,
 } = defineProps<{
   src: string;
   ext: string;
@@ -31,6 +33,12 @@ const {
   prefer?: "largest" | "smallest";
   /** Range-limit the download; the preview must fall within these bytes */
   maxBytes?: number;
+  /**
+   * Show a preview only if one is already cached, never fetch to derive it.
+   * For lists where the source is a multi-MB file and a placeholder is a fairer
+   * trade than pulling it over the camera's Wi-Fi for a thumbnail.
+   */
+  cacheOnly?: boolean;
 }>();
 
 const el = useTemplateRef("el");
@@ -81,31 +89,6 @@ async function downloadBuffer(response: Response): Promise<ArrayBuffer> {
     offset += chunk.length;
   }
   return out.buffer;
-}
-
-/**
- * Render an uncompressed CFA RAW (e.g. Insta360 Luna DNG) to a preview JPEG
- * data URL via canvas. Synchronous encode (toDataURL) is used deliberately: it
- * can't leave us waiting on a canvas.toBlob callback that never fires. Returns
- * null when the file isn't a supported raw or the canvas is unavailable.
- */
-function decodeRawToDataUrl(buffer: ArrayBuffer): string | null {
-  try {
-    const meta = parseRawImageMeta(buffer);
-    if (!meta) return null;
-    const decoded = decodeRawPreview(buffer, meta, 1600);
-    if (!decoded) return null;
-    const canvas = document.createElement("canvas");
-    canvas.width = decoded.width;
-    canvas.height = decoded.height;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return null;
-    ctx.putImageData(new ImageData(decoded.data, decoded.width, decoded.height), 0, 0);
-    return canvas.toDataURL("image/jpeg", 0.9);
-  } catch {
-    // An allocation or canvas failure must read as decode-failed, not no-preview.
-    return null;
-  }
 }
 
 /**
@@ -175,9 +158,16 @@ async function load() {
   phase.value = "downloading";
   // Full-screen preview outranks grid thumbnails for the shared camera slots.
   const priority = maxBytes ? CAMERA_PRIORITY.THUMBNAIL : CAMERA_PRIORITY.PREVIEW;
-  // Key on everything that changes the derived output: a range-limited grid
-  // thumbnail and a full-file preview of one file are different artifacts.
-  const key = `raw:${src}:${maxBytes ?? "full"}:${prefer}`;
+  const key = rawPreviewKey(src, { maxBytes, prefer });
+
+  // Cache-only: a download may have seeded this preview from bytes it already
+  // held. If it didn't, fall back rather than pulling the source file.
+  if (cacheOnly && !hasCachedMedia(key)) {
+    reason.value = "no-preview";
+    state.value = "nopreview";
+    return;
+  }
+
   try {
     const result = await cachedMedia(key, () => fetchPreview(priority));
 

--- a/app/components/WatermarkSettingsForm.vue
+++ b/app/components/WatermarkSettingsForm.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { WATERMARK_POSITIONS, type WatermarkPosition } from "~/utils/watermark";
 
-defineProps<{ previewSrc?: string }>();
+const {
+  note = "The official watermark is rendered into JPEG photos. RAW files and videos transfer untouched.",
+} = defineProps<{ previewSrc?: string; note?: string }>();
 
 const { settings } = useWatermarkSettings();
 
@@ -24,11 +26,7 @@ const anchorClasses: Record<WatermarkPosition, string> = {
 
 <template>
   <div class="space-y-5">
-    <USwitch
-      v-model="settings.enabled"
-      label="Apply Luna Ultra watermark"
-      description="The official watermark is rendered into photos. Videos transfer untouched."
-    />
+    <USwitch v-model="settings.enabled" label="Apply Luna Ultra watermark" :description="note" />
 
     <div v-if="settings.enabled" class="grid grid-cols-[1fr_auto] items-start gap-4">
       <WatermarkCanvas :src="previewSrc" />

--- a/app/composables/useDownloads.ts
+++ b/app/composables/useDownloads.ts
@@ -1,5 +1,6 @@
 import type { DownloadEntry, MediaItem } from "~/types/media";
 import { canWatermark, watermarkNote, watermarkScope } from "~/utils/watermark";
+import { cacheRawPreviewFromBlob, isRawPhoto } from "~/utils/rawPreviewCache";
 import { renderWatermarked } from "~/utils/watermarkClient";
 import { saveBlob } from "~/utils/saveFile";
 import { getCameraTransport } from "~/utils/transport";
@@ -33,10 +34,11 @@ export function useDownloads() {
         const response = await getCameraTransport().fetch(entry.item.srcUrl);
         if (!response.ok) throw new Error(`Camera transfer failed (${response.status})`);
         patch(entry.id, { progress: 45 });
-        let blob = await response.blob();
+        const source = await response.blob();
+        let blob = source;
         // Measured before the watermark pass: this is the file's size on the
         // camera, not the size of what we are about to write to disk.
-        recordSize(entry.item, blob.size);
+        recordSize(entry.item, source.size);
         patch(entry.id, { progress: 70 });
         // Renderable photos only: RAW is `type: "photo"` too, but the canvas
         // pipeline cannot decode it, so it saves unmodified (issue #2).
@@ -46,6 +48,7 @@ export function useDownloads() {
         patch(entry.id, { progress: 90 });
         const savedTo = await saveBlob(blob, entry.item.name);
         patch(entry.id, { status: "done", progress: 100, savedTo });
+        await seedRawPreview(entry.item, source);
       } catch (error) {
         patch(entry.id, {
           status: "error",
@@ -72,6 +75,27 @@ export function useDownloads() {
     item.size = size;
     const libraryItem = library.value.find((candidate) => candidate.id === item.id);
     if (libraryItem && libraryItem !== item) libraryItem.size = size;
+  }
+
+  /**
+   * Derive a RAW's preview from the bytes this transfer already pulled.
+   *
+   * A `.dng` is `renderable: false`, so every surface showing one — the
+   * Downloads row, the gallery tile — otherwise has nothing to display but a
+   * placeholder, and deriving it on demand would mean re-fetching tens of MB
+   * over the camera's Wi-Fi for a thumbnail. Seeding the shared media cache
+   * here makes that view free.
+   *
+   * Runs after the entry is marked done, and swallows failures: the file is
+   * already on disk, and a thumbnail is not worth failing a good download over.
+   */
+  async function seedRawPreview(item: MediaItem, source: Blob) {
+    if (!isRawPhoto(item)) return;
+    try {
+      await cacheRawPreviewFromBlob(item, source);
+    } catch {
+      // Cosmetic only — the download itself succeeded.
+    }
   }
 
   /**

--- a/app/composables/useDownloads.ts
+++ b/app/composables/useDownloads.ts
@@ -5,6 +5,7 @@ import { getCameraTransport } from "~/utils/transport";
 
 export function useDownloads() {
   const queue = useState<DownloadEntry[]>("download-queue", () => []);
+  const { library } = useCamera();
   const { settings } = useWatermarkSettings();
   const toast = useToast();
   const running = useState<boolean>("download-running", () => false);
@@ -32,6 +33,9 @@ export function useDownloads() {
         if (!response.ok) throw new Error(`Camera transfer failed (${response.status})`);
         patch(entry.id, { progress: 45 });
         let blob = await response.blob();
+        // Measured before the watermark pass: this is the file's size on the
+        // camera, not the size of what we are about to write to disk.
+        recordSize(entry.item, blob.size);
         patch(entry.id, { progress: 70 });
         if (entry.watermarked && entry.item.type === "photo") {
           blob = await renderWatermarked(blob, settings.value);
@@ -46,6 +50,25 @@ export function useDownloads() {
         });
       }
     }
+  }
+
+  /**
+   * Record the transferred byte count. On firmware that disabled the HTTP
+   * autoindex the library comes from GET_FILE_LIST, which reports no size, so
+   * a downloaded file is the only place a real byte count ever appears — the
+   * Downloads row would otherwise read `0 B`. `blob.size` is exact and needs
+   * no `content-length` support, and it also beats the index listing's rounded
+   * "18M", so it wins over whatever the item carried.
+   *
+   * Written back to the shared library item as well as the queue entry: the
+   * gallery may hand over a copy, and the size belongs to the file rather than
+   * to this one transfer, so re-downloading isn't the only way to learn it.
+   */
+  function recordSize(item: MediaItem, size: number) {
+    if (size <= 0) return;
+    item.size = size;
+    const libraryItem = library.value.find((candidate) => candidate.id === item.id);
+    if (libraryItem && libraryItem !== item) libraryItem.size = size;
   }
 
   /**

--- a/app/composables/useDownloads.ts
+++ b/app/composables/useDownloads.ts
@@ -1,4 +1,5 @@
 import type { DownloadEntry, MediaItem } from "~/types/media";
+import { canWatermark, watermarkNote, watermarkScope } from "~/utils/watermark";
 import { renderWatermarked } from "~/utils/watermarkClient";
 import { saveBlob } from "~/utils/saveFile";
 import { getCameraTransport } from "~/utils/transport";
@@ -33,7 +34,9 @@ export function useDownloads() {
         patch(entry.id, { progress: 45 });
         let blob = await response.blob();
         patch(entry.id, { progress: 70 });
-        if (entry.watermarked && entry.item.type === "photo") {
+        // Renderable photos only: RAW is `type: "photo"` too, but the canvas
+        // pipeline cannot decode it, so it saves unmodified (issue #2).
+        if (entry.watermarked && canWatermark(entry.item)) {
           blob = await renderWatermarked(blob, settings.value);
         }
         patch(entry.id, { progress: 90 });
@@ -70,9 +73,10 @@ export function useDownloads() {
       startedAt: stamp + index,
     }));
     queue.value = [...entries, ...queue.value];
+    const scope = watermarkScope(items);
     toast.add({
       title: `Downloading ${items.length} ${items.length === 1 ? "file" : "files"}`,
-      description: options.watermark ? "Watermark will be applied to photos" : undefined,
+      description: options.watermark ? watermarkNote(scope) : undefined,
       icon: "i-lucide-arrow-down-to-line",
     });
     if (!running.value) {

--- a/app/pages/downloads.vue
+++ b/app/pages/downloads.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatBytes } from "~/utils/media";
+import { canWatermark } from "~/utils/watermark";
 
 useHead({ title: "Downloads" });
 
@@ -76,7 +77,7 @@ const hasFinished = computed(() =>
             <div class="flex items-center gap-2">
               <p class="truncate font-mono text-sm text-highlighted">{{ entry.item.name }}</p>
               <UBadge
-                v-if="entry.watermarked && entry.item.type === 'photo'"
+                v-if="entry.watermarked && canWatermark(entry.item)"
                 variant="subtle"
                 size="sm"
                 icon="i-lucide-stamp"

--- a/app/pages/downloads.vue
+++ b/app/pages/downloads.vue
@@ -66,9 +66,25 @@ const hasFinished = computed(() =>
               img-class="size-full object-cover"
             />
             <CameraImage
-              v-else
+              v-else-if="entry.item.renderable"
               :src="entry.item.srcUrl"
               :alt="entry.item.name"
+              img-class="size-full object-cover"
+            />
+            <!-- RAW with a sibling JPG (RAW+JPEG pair): show the JPG -->
+            <CameraImage
+              v-else-if="entry.item.previewUrl"
+              :src="entry.item.previewUrl"
+              :alt="entry.item.name"
+              img-class="size-full object-cover"
+            />
+            <!-- RAW: the transfer seeds a preview from the bytes it downloaded,
+                 so this reads the cache rather than re-fetching the file. -->
+            <RawImage
+              v-else
+              :src="entry.item.srcUrl"
+              :ext="entry.item.ext"
+              cache-only
               img-class="size-full object-cover"
             />
           </div>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -121,7 +121,7 @@ useHead({ title: "Settings" });
           <div class="space-y-1">
             <h2 class="text-sm font-semibold text-highlighted">Watermark</h2>
             <p class="text-sm text-muted">
-              Applied to photos as they download. Videos transfer untouched.
+              Applied to JPEG photos as they download. RAW files and videos transfer untouched.
             </p>
           </div>
 

--- a/app/types/media.ts
+++ b/app/types/media.ts
@@ -17,7 +17,11 @@ export interface MediaItem {
   panoramic: boolean;
   /** Unix epoch ms of capture time (filename timestamp, else index column) */
   takenAt: number;
-  /** File size in bytes, parsed from the camera's index listing */
+  /**
+   * File size in bytes, parsed from the camera's index listing. 0 when the
+   * listing came from GET_FILE_LIST, which reports no size; a download
+   * measures the real count and writes it back here.
+   */
   size: number;
   /** Pixel dimensions are unknown until the file is decoded */
   width?: number;

--- a/app/utils/lunaIndex.ts
+++ b/app/utils/lunaIndex.ts
@@ -184,7 +184,9 @@ export function buildMediaItems(
  * Build raw entries from GET_FILE_LIST paths. Firmware 1.0.238+ disabled the
  * HTTP directory autoindex, so files are enumerated over the control session
  * instead; each file stays fetchable by its URL while the session is held.
- * Size isn't reported here — it's resolved lazily when a file is downloaded.
+ * Size isn't reported by GET_FILE_LIST, so entries start at 0 and stay there
+ * until the file is downloaded: `useDownloads` measures the transferred blob
+ * and writes the byte count back onto the library item.
  */
 export function entriesFromPaths(paths: string[], urlFor: (path: string) => string): RawEntry[] {
   const entries: RawEntry[] = [];

--- a/app/utils/mediaCache.ts
+++ b/app/utils/mediaCache.ts
@@ -123,3 +123,16 @@ export function cachedMedia<T extends CachedMedia>(
 ): Promise<T | null> {
   return mediaCache.get(key, load);
 }
+
+/**
+ * Whether a derived artifact is already held. Lets a viewer render a cached
+ * preview without offering to fetch the (multi-MB) source behind it.
+ */
+export function hasCachedMedia(key: string): boolean {
+  return mediaCache.has(key);
+}
+
+/** Drop every entry. Intended for tests and teardown. */
+export function clearCachedMedia(): void {
+  mediaCache.clear();
+}

--- a/app/utils/rawCanvas.ts
+++ b/app/utils/rawCanvas.ts
@@ -1,0 +1,29 @@
+import { parseRawImageMeta, decodeRawPreview } from "./rawPreview";
+
+/**
+ * Render an uncompressed CFA RAW (e.g. Insta360 Luna DNG) to a preview JPEG
+ * data URL via canvas. Synchronous encode (toDataURL) is used deliberately: it
+ * can't leave us waiting on a canvas.toBlob callback that never fires. Returns
+ * null when the file isn't a supported raw or the canvas is unavailable.
+ *
+ * Browser only — split out of RawImage.vue so the download path can derive the
+ * same preview from bytes it already holds, without mounting a component.
+ */
+export function decodeRawToDataUrl(buffer: ArrayBuffer, maxEdge = 1600): string | null {
+  try {
+    const meta = parseRawImageMeta(buffer);
+    if (!meta) return null;
+    const decoded = decodeRawPreview(buffer, meta, maxEdge);
+    if (!decoded) return null;
+    const canvas = document.createElement("canvas");
+    canvas.width = decoded.width;
+    canvas.height = decoded.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.putImageData(new ImageData(decoded.data, decoded.width, decoded.height), 0, 0);
+    return canvas.toDataURL("image/jpeg", 0.9);
+  } catch {
+    // An allocation or canvas failure must read as decode-failed, not no-preview.
+    return null;
+  }
+}

--- a/app/utils/rawPreviewCache.ts
+++ b/app/utils/rawPreviewCache.ts
@@ -1,0 +1,59 @@
+import type { MediaItem } from "~/types/media";
+import { cachedMedia, hasCachedMedia } from "./mediaCache";
+import { extractDngPreview } from "./dng";
+import { decodeRawToDataUrl } from "./rawCanvas";
+
+/**
+ * Cache key for a RAW's derived preview.
+ *
+ * Shared by RawImage (which derives it on demand) and the download path (which
+ * seeds it from bytes already in hand) so the two can't drift apart and miss
+ * each other's work. Every input that changes the derived output is in the key:
+ * a range-limited grid thumbnail and a full-file preview are different
+ * artifacts of the same source.
+ */
+export function rawPreviewKey(
+  src: string,
+  options: { maxBytes?: number; prefer?: "largest" | "smallest" } = {},
+): string {
+  const { maxBytes, prefer = "largest" } = options;
+  return `raw:${src}:${maxBytes ?? "full"}:${prefer}`;
+}
+
+/** A photo the browser can't decode itself — i.e. RAW, which needs a preview. */
+export function isRawPhoto(item: MediaItem): boolean {
+  return item.type === "photo" && !item.renderable;
+}
+
+/**
+ * Derive a RAW's preview from the file's own bytes and seed the media cache.
+ *
+ * A download already holds the whole file, so this costs no extra network and
+ * no camera-queue slot — the alternative is re-fetching tens of MB to show a
+ * thumbnail. Prefers an embedded preview JPEG and falls back to decoding the
+ * Bayer sensor data (the Luna's DNGs carry no embedded preview).
+ *
+ * Returns the preview, or null when the file yields none. Never throws: a
+ * cosmetic thumbnail must not be able to fail a download that already
+ * succeeded.
+ */
+export async function cacheRawPreviewFromBlob(
+  item: MediaItem,
+  blob: Blob,
+): Promise<string | Blob | null> {
+  const key = rawPreviewKey(item.srcUrl);
+  // The viewer may already have derived this; its value is as good as ours and
+  // re-deriving would burn CPU to replace it with an identical result.
+  if (hasCachedMedia(key)) return await cachedMedia(key, async () => null);
+
+  return await cachedMedia(key, async () => {
+    try {
+      const buffer = await blob.arrayBuffer();
+      const embedded = extractDngPreview(buffer, "largest");
+      if (embedded) return embedded;
+      return decodeRawToDataUrl(buffer);
+    } catch {
+      return null;
+    }
+  });
+}

--- a/app/utils/watermark.ts
+++ b/app/utils/watermark.ts
@@ -1,3 +1,4 @@
+import type { MediaItem } from "~/types/media";
 import { LUNA_WATERMARK_LAYOUT } from "./watermarkLayout";
 
 export type WatermarkPosition =
@@ -42,6 +43,57 @@ export const DEFAULT_WATERMARK: WatermarkSettings = {
   enabled: true,
   position: "bottom-left",
 };
+
+/**
+ * Whether the watermark can be burned into this file at all.
+ *
+ * The pipeline is canvas-based — `createImageBitmap`, draw, re-encode to JPEG —
+ * so it only works on files the browser can decode. RAW (`.dng`) is
+ * `type: "photo"` but `renderable: false`: no engine decodes a raw Bayer frame,
+ * and watermarking one would mean demosaicing it into a JPEG, i.e. not
+ * returning the file the user asked for. Those save unmodified instead.
+ */
+export function canWatermark(item: MediaItem): boolean {
+  return item.type === "photo" && item.renderable;
+}
+
+/** A selection split by what watermarking can actually do to each file. */
+export interface WatermarkScope {
+  /** Renderable photos — the watermark is burned into these. */
+  watermarkable: MediaItem[];
+  /** RAW photos, saved byte-for-byte whatever the watermark setting says. */
+  raw: MediaItem[];
+  /** Videos, likewise untouched. */
+  videos: MediaItem[];
+}
+
+/** Split `items` so the UI can say honestly which files get a watermark. */
+export function watermarkScope(items: MediaItem[]): WatermarkScope {
+  const scope: WatermarkScope = { watermarkable: [], raw: [], videos: [] };
+  for (const item of items) {
+    if (item.type === "video") scope.videos.push(item);
+    else if (canWatermark(item)) scope.watermarkable.push(item);
+    else scope.raw.push(item);
+  }
+  return scope;
+}
+
+/**
+ * One honest sentence about what the watermark will do to this selection.
+ *
+ * Shared by the download modal and the queue toast so neither can drift into
+ * promising a watermark on files that will be saved untouched.
+ */
+export function watermarkNote(scope: WatermarkScope): string {
+  if (scope.watermarkable.length > 0) {
+    return scope.raw.length > 0
+      ? "Watermark will be applied to JPEG photos; RAW files are saved unmodified."
+      : "Watermark will be applied to photos.";
+  }
+  return scope.raw.length > 0
+    ? "RAW files are saved unmodified; watermarking applies to JPEG photos only."
+    : "Videos transfer untouched; watermarking applies to JPEG photos only.";
+}
 
 /** Snap an image to the closest aspect ratio in the official layout table. */
 export function nearestAspect(width: number, height: number): string {

--- a/app/utils/watermarkClient.ts
+++ b/app/utils/watermarkClient.ts
@@ -15,7 +15,7 @@ import type { WatermarkRequest, WatermarkResponse } from "~/workers/watermark.wo
  * original main-thread path rather than failing the download.
  */
 
-/** Which route the last render actually took. */
+/** Which route the last render actually took; `passthrough` means "off". */
 export type WatermarkPath = "worker" | "main-thread" | "passthrough";
 
 let lastPath: WatermarkPath = "passthrough";
@@ -102,20 +102,30 @@ async function renderOnMainThread(blob: Blob, settings: WatermarkSettings): Prom
   const context = canvas.getContext("2d");
   if (!context) {
     bitmap.close();
-    return blob;
+    throw new Error("Canvas 2D context unavailable");
   }
   context.drawImage(bitmap, 0, 0);
   await drawWatermark(context, bitmap.width, bitmap.height, settings);
   bitmap.close();
-  return await new Promise<Blob>((resolve) => {
-    canvas.toBlob((out) => resolve(out ?? blob), "image/jpeg", WATERMARK_JPEG_QUALITY);
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (out) => (out ? resolve(out) : reject(new Error("Watermark encode produced no data"))),
+      "image/jpeg",
+      WATERMARK_JPEG_QUALITY,
+    );
   });
 }
 
 /**
  * Return `blob` with the watermark applied. Returns the original untouched
- * when watermarking is off — no point paying a re-encode to change nothing —
- * and on any rendering failure, so a download never fails over decoration.
+ * only when watermarking is off — no point paying a re-encode to change
+ * nothing.
+ *
+ * A failure in both render paths throws. It used to return the original blob,
+ * which meant a download the user asked to watermark could report success with
+ * an unwatermarked file on disk (issue #2, where RAW reached here at all).
+ * Callers must not send files `canWatermark()` rejects; anything else failing
+ * is a genuine render fault and a silent success would be a lie.
  */
 export async function renderWatermarked(blob: Blob, settings: WatermarkSettings): Promise<Blob> {
   if (!settings.enabled) {
@@ -134,12 +144,7 @@ export async function renderWatermarked(blob: Blob, settings: WatermarkSettings)
     }
   }
 
-  try {
-    const out = await renderOnMainThread(blob, settings);
-    lastPath = "main-thread";
-    return out;
-  } catch {
-    lastPath = "passthrough";
-    return blob;
-  }
+  const out = await renderOnMainThread(blob, settings);
+  lastPath = "main-thread";
+  return out;
 }

--- a/tests/lunaIndex.test.ts
+++ b/tests/lunaIndex.test.ts
@@ -171,6 +171,10 @@ describe("GET_FILE_LIST path listing (firmware 1.0.238+)", () => {
     expect(dng.previewUrl).toBe("http://192.168.42.1/DCIM/Camera01/IMG_20260724_134210_135.jpg");
   });
 
+  it("leaves size at 0 for a download to measure and fill in", () => {
+    expect(items.every((i) => i.size === 0)).toBe(true);
+  });
+
   it("parses the capture time from the filename", () => {
     const vid = items.find((i) => i.ext === "mp4")!;
     expect(vid.takenAt).toBe(new Date(2026, 6, 24, 18, 20, 11).getTime());

--- a/tests/nuxt/useDownloads.test.ts
+++ b/tests/nuxt/useDownloads.test.ts
@@ -1,6 +1,6 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DownloadEntry } from "~/types/media";
+import type { DownloadEntry, MediaItem } from "~/types/media";
 import { resetCameraTransport, setCameraTransport } from "~/utils/transport";
 import { makeFakeTransport } from "../helpers/fakeTransport";
 import { makeMediaItem } from "../helpers/media";
@@ -23,8 +23,16 @@ const saveBlob = vi.hoisted(() =>
   vi.fn(async (_blob: Blob, fileName: string) => `Downloads/Luna Ultra/${fileName}`),
 );
 
+const cacheRawPreviewFromBlob = vi.hoisted(() =>
+  vi.fn(async (_item: MediaItem, _source: Blob): Promise<string | Blob | null> => null),
+);
+
 vi.mock("~/utils/watermarkClient", () => ({ renderWatermarked }));
 vi.mock("~/utils/saveFile", () => ({ saveBlob, isTauri: () => false }));
+vi.mock("~/utils/rawPreviewCache", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/utils/rawPreviewCache")>();
+  return { ...original, cacheRawPreviewFromBlob };
+});
 
 mockNuxtImport("useToast", () => () => ({
   add: vi.fn(),
@@ -55,6 +63,7 @@ describe("useDownloads", () => {
     localStorage.clear();
     renderWatermarked.mockClear();
     saveBlob.mockClear();
+    cacheRawPreviewFromBlob.mockClear();
     setCameraTransport(respondWith(CAMERA_BYTES));
   });
 
@@ -169,6 +178,43 @@ describe("useDownloads", () => {
     await settled(downloads.queue);
 
     expect(renderWatermarked).not.toHaveBeenCalled();
+  });
+
+  it("derives a RAW preview from the bytes it already downloaded", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+    const item = makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false });
+
+    downloads.enqueue([item], { watermark: false });
+    await settled(downloads.queue);
+
+    expect(cacheRawPreviewFromBlob).toHaveBeenCalledTimes(1);
+    const [seededItem, seededBlob] = cacheRawPreviewFromBlob.mock.calls[0]!;
+    expect(seededItem.id).toBe("dng");
+    // The camera's own bytes, not a re-fetch.
+    expect(seededBlob.size).toBe(CAMERA_BYTES);
+  });
+
+  it("does not derive a preview for a photo the browser can render", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ name: "IMG_0001.jpg" })], { watermark: false });
+    await settled(downloads.queue);
+
+    expect(cacheRawPreviewFromBlob).not.toHaveBeenCalled();
+  });
+
+  it("still completes the download when deriving the RAW preview fails", async () => {
+    cacheRawPreviewFromBlob.mockRejectedValueOnce(new Error("decode blew up"));
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue(
+      [makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false })],
+      { watermark: false },
+    );
+    await settled(downloads.queue);
+
+    expect(saveBlob).toHaveBeenCalledTimes(1);
+    expect(downloads.queue.value[0]?.status).toBe("done");
   });
 
   it("fails the download when watermarking a renderable photo throws", async () => {

--- a/tests/nuxt/useDownloads.test.ts
+++ b/tests/nuxt/useDownloads.test.ts
@@ -1,0 +1,93 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DownloadEntry } from "~/types/media";
+import { resetCameraTransport, setCameraTransport } from "~/utils/transport";
+import { makeFakeTransport } from "../helpers/fakeTransport";
+import { makeMediaItem } from "../helpers/media";
+import { mountComposable } from "./harness";
+
+const renderWatermarked = vi.hoisted(() => vi.fn(async (blob: Blob) => blob));
+const saveBlob = vi.hoisted(() => vi.fn(async () => "Downloads/Luna Ultra/file"));
+
+vi.mock("~/utils/watermarkClient", () => ({ renderWatermarked }));
+vi.mock("~/utils/saveFile", () => ({ saveBlob, isTauri: () => false }));
+
+mockNuxtImport("useToast", () => () => ({
+  add: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  clear: vi.fn(),
+  toasts: [],
+}));
+
+/** Wait for the queue drain kicked off by `enqueue` to settle. */
+async function settled(queue: { value: DownloadEntry[] }): Promise<void> {
+  for (let tick = 0; tick < 50; tick++) {
+    if (queue.value.every((entry) => entry.status === "done" || entry.status === "error")) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("useDownloads", () => {
+  beforeEach(() => {
+    renderWatermarked.mockClear();
+    saveBlob.mockClear();
+    setCameraTransport(
+      makeFakeTransport({
+        fetch: vi.fn(async () => new Response(new Blob(["photo-bytes"]), { status: 200 })),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    resetCameraTransport();
+    clearNuxtState(["download-queue", "download-running", "watermark-settings"], { reset: true });
+  });
+
+  it("watermarks renderable photos", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" })], { watermark: true });
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).toHaveBeenCalledTimes(1);
+    expect(downloads.queue.value[0]?.status).toBe("done");
+  });
+
+  it("saves RAW photos unmodified instead of pretending to watermark them", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue(
+      [makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false })],
+      { watermark: true },
+    );
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).not.toHaveBeenCalled();
+    expect(saveBlob).toHaveBeenCalledTimes(1);
+    expect(downloads.queue.value[0]?.status).toBe("done");
+  });
+
+  it("never watermarks videos", async () => {
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video" })], {
+      watermark: true,
+    });
+    await settled(downloads.queue);
+
+    expect(renderWatermarked).not.toHaveBeenCalled();
+  });
+
+  it("fails the download when watermarking a renderable photo throws", async () => {
+    renderWatermarked.mockRejectedValueOnce(new Error("watermark render failed"));
+    const downloads = await mountComposable(() => useDownloads());
+
+    downloads.enqueue([makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" })], { watermark: true });
+    await settled(downloads.queue);
+
+    expect(saveBlob).not.toHaveBeenCalled();
+    expect(downloads.queue.value[0]?.status).toBe("error");
+    expect(downloads.queue.value[0]?.error).toBe("watermark render failed");
+  });
+});

--- a/tests/nuxt/useDownloads.test.ts
+++ b/tests/nuxt/useDownloads.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetCameraTransport, setCameraTransport } from "~/utils/transport";
+import { makeFakeTransport } from "../helpers/fakeTransport";
+import { makeMediaItem } from "../helpers/media";
+import { mountComposable } from "./harness";
+
+vi.mock("~/utils/saveFile", () => ({
+  isTauri: () => false,
+  saveBlob: vi.fn(async (_blob: Blob, fileName: string) => `Downloads/Luna Ultra/${fileName}`),
+}));
+
+const renderWatermarked = vi.fn(async (_blob: Blob, _settings: unknown) =>
+  bodyOf(WATERMARKED_BYTES),
+);
+vi.mock("~/utils/watermarkClient", () => ({
+  renderWatermarked: (blob: Blob, settings: unknown) => renderWatermarked(blob, settings),
+}));
+
+const CAMERA_BYTES = 4096;
+const WATERMARKED_BYTES = 9000;
+
+function bodyOf(bytes: number): Blob {
+  return new Blob([new Uint8Array(bytes)]);
+}
+
+function respondWith(bytes: number) {
+  // Uint8Array rather than a Blob body: this environment's Response
+  // stringifies a Blob instead of streaming it.
+  return makeFakeTransport({
+    fetch: vi.fn(async () => new Response(new Uint8Array(bytes), { status: 200 })),
+  });
+}
+
+/** Resolve once every queued transfer has left the queue's active states. */
+async function drain(active: { value: unknown[] }) {
+  for (let tick = 0; tick < 100 && active.value.length > 0; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("useDownloads", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    renderWatermarked.mockClear();
+  });
+
+  afterEach(() => {
+    resetCameraTransport();
+    clearNuxtState(
+      [
+        "download-queue",
+        "download-running",
+        "watermark-settings",
+        "camera-library",
+        "camera-host",
+        "camera-status",
+        "camera-info",
+        "camera-error",
+        "camera-library-loading",
+        "camera-want-connection",
+        "camera-retry-attempt",
+      ],
+      { reset: true },
+    );
+  });
+
+  it("records the transferred byte count on an entry the file list left at zero", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: false });
+    await drain(downloads.active);
+
+    const entry = downloads.queue.value[0]!;
+    expect(entry.status).toBe("done");
+    expect(entry.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("backfills the size onto the shared library item, not just the queue entry", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const { camera, downloads } = await mountComposable(() => ({
+      camera: useCamera(),
+      downloads: useDownloads(),
+    }));
+    camera.library.value = [makeMediaItem({ size: 0 })];
+    // The gallery can hand over a copy, so the entry and the library item are
+    // not guaranteed to be the same object.
+    downloads.enqueue([{ ...camera.library.value[0]! }], { watermark: false });
+    await drain(downloads.active);
+
+    expect(camera.library.value[0]!.size).toBe(CAMERA_BYTES);
+  });
+
+  it("records the camera file's size, not the watermarked output's", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: true });
+    await drain(downloads.active);
+
+    expect(renderWatermarked).toHaveBeenCalled();
+    expect(downloads.queue.value[0]!.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("replaces an index-estimated size with the exact byte count", async () => {
+    setCameraTransport(respondWith(CAMERA_BYTES));
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 18 * 1024 * 1024 })], { watermark: false });
+    await drain(downloads.active);
+
+    expect(downloads.queue.value[0]!.item.size).toBe(CAMERA_BYTES);
+  });
+
+  it("leaves the size untouched when the transfer fails", async () => {
+    setCameraTransport(
+      makeFakeTransport({
+        fetch: vi.fn(async () => new Response(null, { status: 404 })),
+      }),
+    );
+
+    const downloads = await mountComposable(() => useDownloads());
+    downloads.enqueue([makeMediaItem({ size: 0 })], { watermark: false });
+    await drain(downloads.active);
+
+    const entry = downloads.queue.value[0]!;
+    expect(entry.status).toBe("error");
+    expect(entry.item.size).toBe(0);
+  });
+});

--- a/tests/rawPreviewCache.test.ts
+++ b/tests/rawPreviewCache.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { rawPreviewKey, isRawPhoto, cacheRawPreviewFromBlob } from "~/utils/rawPreviewCache";
+import { hasCachedMedia, cachedMedia, clearCachedMedia } from "~/utils/mediaCache";
+import { makeMediaItem } from "./helpers/media";
+
+vi.mock("~/utils/rawCanvas", () => ({
+  decodeRawToDataUrl: vi.fn(() => "data:image/jpeg;base64,DECODED"),
+}));
+
+vi.mock("~/utils/dng", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/utils/dng")>();
+  return { ...original, extractDngPreview: vi.fn(() => null) };
+});
+
+const raw = () => makeMediaItem({ id: "dng", name: "IMG_1.dng", ext: "dng", renderable: false });
+
+describe("rawPreviewKey", () => {
+  it("builds the full-file key the download seeds and the viewer reads", () => {
+    expect(rawPreviewKey("http://cam/IMG_1.dng")).toBe("raw:http://cam/IMG_1.dng:full:largest");
+  });
+
+  it("keys a range-limited grid thumbnail apart from the full-file preview", () => {
+    const thumb = rawPreviewKey("http://cam/IMG_1.dng", { maxBytes: 2000, prefer: "smallest" });
+    expect(thumb).not.toBe(rawPreviewKey("http://cam/IMG_1.dng"));
+  });
+});
+
+describe("isRawPhoto", () => {
+  it("accepts a photo the browser cannot render", () => {
+    expect(isRawPhoto(raw())).toBe(true);
+  });
+
+  it("rejects renderable photos and videos", () => {
+    expect(isRawPhoto(makeMediaItem({ name: "IMG_1.jpg" }))).toBe(false);
+    expect(isRawPhoto(makeMediaItem({ name: "VID_1.mp4", type: "video" }))).toBe(false);
+  });
+});
+
+describe("cacheRawPreviewFromBlob", () => {
+  beforeEach(() => {
+    clearCachedMedia();
+  });
+
+  it("seeds a preview under the key the viewer will look up", async () => {
+    const item = raw();
+    await cacheRawPreviewFromBlob(item, new Blob([new Uint8Array(64)]));
+
+    expect(hasCachedMedia(rawPreviewKey(item.srcUrl))).toBe(true);
+    const cached = await cachedMedia(rawPreviewKey(item.srcUrl), async () => null);
+    expect(cached).toBe("data:image/jpeg;base64,DECODED");
+  });
+
+  it("does not overwrite a preview the viewer already derived", async () => {
+    const item = raw();
+    await cachedMedia(rawPreviewKey(item.srcUrl), async () => "data:image/jpeg;base64,EXISTING");
+
+    await cacheRawPreviewFromBlob(item, new Blob([new Uint8Array(64)]));
+
+    const cached = await cachedMedia(rawPreviewKey(item.srcUrl), async () => null);
+    expect(cached).toBe("data:image/jpeg;base64,EXISTING");
+  });
+
+  it("resolves without throwing when the file yields no preview", async () => {
+    const { decodeRawToDataUrl } = await import("~/utils/rawCanvas");
+    vi.mocked(decodeRawToDataUrl).mockReturnValueOnce(null);
+
+    await expect(cacheRawPreviewFromBlob(raw(), new Blob([new Uint8Array(8)]))).resolves.toBeNull();
+  });
+});

--- a/tests/watermark.test.ts
+++ b/tests/watermark.test.ts
@@ -3,10 +3,14 @@ import {
   DEFAULT_WATERMARK,
   WATERMARK_ASSET_RATIO,
   WATERMARK_POSITIONS,
+  canWatermark,
   nearestAspect,
+  watermarkNote,
   watermarkRect,
+  watermarkScope,
 } from "~/utils/watermark";
 import { LUNA_WATERMARK_LAYOUT } from "~/utils/watermarkLayout";
+import { makeMediaItem } from "./helpers/media";
 
 describe("nearestAspect", () => {
   it("matches exact aspect ratios", () => {
@@ -62,5 +66,76 @@ describe("layout table", () => {
   it("defaults to the official bottom-left placement", () => {
     expect(DEFAULT_WATERMARK.position).toBe("bottom-left");
     expect(DEFAULT_WATERMARK.enabled).toBe(true);
+  });
+});
+
+describe("canWatermark", () => {
+  it("accepts renderable photos", () => {
+    expect(canWatermark(makeMediaItem({ ext: "jpg", renderable: true }))).toBe(true);
+  });
+
+  it("rejects RAW photos the canvas pipeline cannot decode", () => {
+    const dng = makeMediaItem({ name: "IMG_0001.dng", ext: "dng", renderable: false });
+    expect(canWatermark(dng)).toBe(false);
+  });
+
+  it("rejects RAW photos even when a sibling JPEG stands in for the preview", () => {
+    const dng = makeMediaItem({
+      name: "IMG_0001.dng",
+      ext: "dng",
+      renderable: false,
+      previewUrl: "http://127.0.0.1/DCIM/Camera01/IMG_0001.jpg",
+    });
+    expect(canWatermark(dng)).toBe(false);
+  });
+
+  it("rejects videos", () => {
+    expect(canWatermark(makeMediaItem({ type: "video", ext: "mp4" }))).toBe(false);
+  });
+});
+
+describe("watermarkScope", () => {
+  it("splits a mixed selection into watermarkable photos, raw photos and videos", () => {
+    const jpeg = makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" });
+    const raw = makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false });
+    const video = makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video", ext: "mp4" });
+
+    const scope = watermarkScope([jpeg, raw, video]);
+
+    expect(scope.watermarkable).toEqual([jpeg]);
+    expect(scope.raw).toEqual([raw]);
+    expect(scope.videos).toEqual([video]);
+  });
+
+  it("reports an empty scope for an empty selection", () => {
+    expect(watermarkScope([])).toEqual({ watermarkable: [], raw: [], videos: [] });
+  });
+});
+
+describe("watermarkNote", () => {
+  const jpeg = makeMediaItem({ id: "jpg", name: "IMG_0001.jpg" });
+  const raw = makeMediaItem({ id: "dng", name: "IMG_0001.dng", ext: "dng", renderable: false });
+  const video = makeMediaItem({ id: "mp4", name: "VID_0001.mp4", type: "video", ext: "mp4" });
+
+  it("promises the watermark without qualification when every photo is renderable", () => {
+    expect(watermarkNote(watermarkScope([jpeg]))).toBe("Watermark will be applied to photos.");
+  });
+
+  it("says RAW is left alone when the selection mixes JPEG and RAW", () => {
+    expect(watermarkNote(watermarkScope([jpeg, raw]))).toBe(
+      "Watermark will be applied to JPEG photos; RAW files are saved unmodified.",
+    );
+  });
+
+  it("promises nothing when the selection is RAW only", () => {
+    const note = watermarkNote(watermarkScope([raw]));
+    expect(note).toBe("RAW files are saved unmodified; watermarking applies to JPEG photos only.");
+    expect(note).not.toMatch(/will be applied/);
+  });
+
+  it("promises nothing when the selection is videos only", () => {
+    expect(watermarkNote(watermarkScope([video]))).toBe(
+      "Videos transfer untouched; watermarking applies to JPEG photos only.",
+    );
   });
 });

--- a/tests/watermarkClient.test.ts
+++ b/tests/watermarkClient.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_WATERMARK, type WatermarkSettings } from "~/utils/watermark";
+import { lastWatermarkPath, renderWatermarked } from "~/utils/watermarkClient";
+
+/**
+ * No Worker, no OffscreenCanvas and no createImageBitmap here, so every render
+ * attempt takes the main-thread path and fails there — which is exactly the
+ * shape of the RAW failure this file guards against being swallowed.
+ */
+const OFF: WatermarkSettings = { ...DEFAULT_WATERMARK, enabled: false };
+
+function photoBlob(): Blob {
+  return new Blob([new Uint8Array([0xff, 0xd8, 0xff])], { type: "image/jpeg" });
+}
+
+describe("renderWatermarked", () => {
+  it("returns the original blob untouched when watermarking is off", async () => {
+    const blob = photoBlob();
+    await expect(renderWatermarked(blob, OFF)).resolves.toBe(blob);
+    expect(lastWatermarkPath()).toBe("passthrough");
+  });
+
+  it("rejects instead of silently returning an unwatermarked blob when the render fails", async () => {
+    await expect(renderWatermarked(photoBlob(), DEFAULT_WATERMARK)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
> **Stacked PR — depends on #6 and #5.** Until both merge, the diff here also shows their changes (this branch builds on #5's `source` refactor in `processNext` and #6's `canWatermark` gate). Merge those two first and this reduces to the RAW-preview commit alone.

## Problem

A `.dng` in the Downloads list rendered as a broken image icon.

`downloads.vue` sent every non-video item to `CameraImage` with the item's `srcUrl`. For a RAW that's raw Bayer sensor data, which no browser can decode. The gallery's `MediaTile` already had a three-tier ladder for exactly this; the Downloads page never used it.

## Fix

The Downloads row now follows the same ladder: renderable JPEG → RAW+JPEG sibling → `RawImage`.

That alone would only get a placeholder, because Luna DNGs carry no embedded preview JPEG — a real thumbnail needs a Bayer decode of the whole file, and re-fetching tens of MB over the camera's Wi-Fi to render a 56px image is not a trade worth making.

So instead **the transfer derives the preview from the bytes it already downloaded** and seeds the shared media cache. The row reads that cache. No extra network, no camera-queue slot.

`RawImage` gains a `cacheOnly` mode to enforce that. This matters: a `RawImage` with no `maxBytes` considers itself a full-file view and would otherwise happily pull the source file to build a thumbnail. In `cacheOnly` it renders a seeded preview or falls back — never fetches.

Because the seeded preview uses the full-file key, opening that same DNG full-screen in the gallery afterwards is now instant instead of re-downloading and re-decoding.

## Two supporting refactors

- The canvas decode moves out of `RawImage.vue` into `app/utils/rawCanvas.ts`, so the download path can reuse it without mounting a component.
- The cache key moves into `app/utils/rawPreviewCache.ts`, so the deriving side and the seeding side can't silently drift apart and miss each other's work.

`processNext` also now captures the pre-watermark blob explicitly as `source`. RAW is never watermarked so the old variable happened to hold the right bytes, but that was an invisible coupling.

Seeding runs *after* the entry is marked done and swallows failures — the file is already on disk, and a thumbnail is not worth failing a good download over.

## Known limitation

Gallery grid tiles key on a range-limited, `prefer=smallest` variant, so a downloaded DNG's preview does **not** light up its gallery thumbnail — that still shows the placeholder. Making tiles fall back to a cached full preview is a small follow-up.

## Tests

`tests/rawPreviewCache.test.ts` (7) — key shape and separation, RAW detection, seeding under the key the viewer reads, not clobbering a preview the viewer already derived, no throw when the file yields nothing.
3 added to `tests/nuxt/useDownloads.test.ts` — derives from the downloaded bytes (asserting the camera's byte count, i.e. not a re-fetch), skips renderable photos, and still completes the download when the decode blows up.

Written first and confirmed red. `bun run test` (318 node + 31 nuxt), `bun run lint`, `bun run typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)